### PR TITLE
fix: add create option for missing install paths

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -17,7 +17,6 @@ from lola.config import MODULES_DIR, MARKET_DIR, CACHE_DIR
 from lola.exceptions import (
     ModuleInvalidError,
     ModuleNotFoundError,
-    PathNotFoundError,
     ValidationError,
 )
 from lola.models import Installation, InstallationRegistry, Module
@@ -759,6 +758,12 @@ def _format_update_summary(result: UpdateResult) -> str:
     default="project",
     help="Installation scope: project (default) or user",
 )
+@click.option(
+    "--create",
+    "create_project_path",
+    is_flag=True,
+    help="Create the project directory if it does not exist",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -770,6 +775,7 @@ def install_cmd(
     append_context: tuple[str, ...],
     workspace: Optional[str],
     scope: str,
+    create_project_path: bool,
     project_path: str,
 ):
     """
@@ -785,6 +791,7 @@ def install_cmd(
         lola install my-module                         # Pick assistants interactively
         lola install my-module -a claude-code          # Specific assistant, no prompt
         lola install my-module ./my-project            # Install in a specific project directory
+        lola install my-module ./my-project --create   # Create project directory if missing
         lola install my-module --append-context module/AGENTS.md   # Single context reference
         lola install my-module --append-context module/AGENTS.md --append-context /opt/guidelines.md  # Multiple context references
         lola install my-module -a openclaw             # Install to ~/.openclaw/workspace/skills/
@@ -833,7 +840,14 @@ def install_cmd(
         # Project scope: validate and resolve project path
         install_project_path = str(Path(project_path).resolve())
         if not Path(install_project_path).exists():
-            handle_lola_error(PathNotFoundError(install_project_path, "Project path"))
+            if create_project_path:
+                Path(install_project_path).mkdir(parents=True)
+            else:
+                click.echo(f"Project path does not exist: {install_project_path}")
+                click.echo(
+                    "Tip: create it first with mkdir -p, or pass --create to have lola create it."
+                )
+                raise SystemExit(1)
         local_modules = get_local_modules_path(install_project_path)
 
     # Default to global registry

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -53,18 +53,45 @@ class TestInstallCmd:
         assert "not found" in result.output
 
     def test_install_project_path_not_exists(self, cli_runner, tmp_path):
-        """Fail when project path doesn't exist."""
+        """Fail with guidance when project path doesn't exist."""
         modules_dir = tmp_path / ".lola" / "modules"
         modules_dir.mkdir(parents=True)
+        missing_path = tmp_path / "missing"
 
         with (
             patch("lola.cli.install.MODULES_DIR", modules_dir),
             patch("lola.cli.install.ensure_lola_dirs"),
         ):
-            result = cli_runner.invoke(install_cmd, ["mymodule", "/nonexistent/path"])
+            result = cli_runner.invoke(install_cmd, ["mymodule", str(missing_path)])
 
         assert result.exit_code == 1
-        assert "does not exist" in result.output
+        assert f"Project path does not exist: {missing_path}" in result.output
+        assert "pass --create to have lola create it" in result.output
+
+    def test_install_create_project_path(self, cli_runner, sample_module, tmp_path):
+        """--create creates a missing project path before installing."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "new-project"
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch("lola.cli.install.install_to_assistant", return_value=1),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", str(project_path), "-a", "claude-code", "--create"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert project_path.is_dir()
+        assert "Installing" in result.output
 
     def test_install_module(self, cli_runner, sample_module, tmp_path):
         """Install a module successfully."""


### PR DESCRIPTION
## Summary

- Add `lola install --create` to create a missing project directory on demand
- Improve the missing project path error with an actionable tip
- Add CLI tests for both the guidance and create flows

## Related Issues

Fixes #191

## Test Plan

- [x] `.venv/bin/python -m pytest tests/test_cli_install.py -q`
- [x] `.venv/bin/python -m pytest -q`
- [x] `.venv/bin/ruff check src tests`
- [x] `.venv/bin/ruff format --check src tests`
- [x] `env -u VIRTUAL_ENV .venv/bin/ty check src`

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Hermes Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--create` option to `lola install` so missing project directories can be created automatically during project-scoped installs.
  * Updated install examples to show the new option.

* **Bug Fixes**
  * Improved the message shown when a project path does not exist, with clearer guidance on how to proceed.
  * Confirmed installs now succeed when the project directory is created as part of the command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->