### PR TITLE
feat: support Agent Plugins v1 module format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ docs/superpowers/
 
 ### SDD — optional contributor tooling (not committed) ###
 .opencode/
+
+### E2E — behave generated output ###
+e2e/features/*.output

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ cd my-skills
 
 This creates an Agent Plugins 1.0 package:
 
-```
+```text
 my-skills/
   plugin.json          # Package manifest
   skills/

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ modules:
 | `lola mod ls` | List registered modules |
 | `lola mod info <name>` | Show module details |
 | `lola mod search <query>` | Search for modules across enabled marketplaces |
-| `lola mod init [name]` | Initialize a new module |
+| `lola mod init [name]` | Initialize an Agent Plugins package |
+| `lola mod init [name] --format lola` | Initialize a legacy Lola module |
 | `lola mod init [name] -c` | Initialize with a command template |
 | `lola mod update [name]` | Update module(s) from source |
 | `lola mod rm <name>` | Remove a module |
@@ -248,18 +249,24 @@ lola mod init my-skills
 cd my-skills
 ```
 
-This creates:
+This creates an Agent Plugins 1.0 package:
 
 ```
 my-skills/
+  plugin.json          # Package manifest
   skills/
     example-skill/
       SKILL.md         # Initial skill (unless --no-skill)
-  commands/            # Created by default
-    example-command.md # (unless --no-command)
-  agents/              # Created by default
-    example-agent.md   # (unless --no-agent)
+  mcp.json             # MCP servers (unless --no-mcps)
+  dev.getlola/         # Lola extension namespace
+    commands/
+      example-command.md # (unless --no-command)
+    agents/
+      example-agent.md   # (unless --no-agent)
+    AGENTS.md            # (unless --no-instructions)
 ```
+
+Use `--format lola` for the legacy `module/` layout.
 
 ### 2. Edit the skill
 

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -10,7 +10,8 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 | `lola mod add <source> --ref <ref>`                  | Add from a specific git branch, tag, or SHA    |
 | `lola mod ls`                                        | List registered modules                        |
 | `lola mod info <name>`                               | Show module details                            |
-| `lola mod init [name]`                               | Initialize a new module                        |
+| `lola mod init [name]`                               | Initialize an Agent Plugins package            |
+| `lola mod init [name] --format lola`                 | Initialize a legacy Lola module                |
 | `lola mod update [name]`                             | Update module(s) from source                   |
 | `lola mod rm <name>`                                 | Remove a module                                |
 

--- a/docs/guides/creating-modules.md
+++ b/docs/guides/creating-modules.md
@@ -2,13 +2,41 @@
 
 Lola modules can be a single [Agent Skill](https://agentskills.io/specification) or a full [AI Context Module](../concepts/skills-and-modules.md). An Agent Skill is a standalone `SKILL.md` with optional supporting files. An AI Context Module is a superset - it wraps one or more skills alongside `AGENTS.md`, `commands/`, and `mcps.json` inside a `module/` directory.
 
-## Initialize an AI Context Module
+## Initialize a Module
 
 ```bash
-lola mod init my-module
+lola mod init my-plugin
 ```
 
-This creates the AI Context Module structure:
+By default this emits an Agent Plugins 1.0 package:
+
+```text
+my-plugin/
+  plugin.json
+  skills/
+    example-skill/
+      SKILL.md
+  mcp.json
+  dev.getlola/
+    commands/
+      example-command.md
+    agents/
+      example-agent.md
+    AGENTS.md
+```
+
+The `name` in `plugin.json` is the module identity used by Lola when the
+package is registered. Portable skills and MCP servers stay at the package
+root. Lola-specific commands, agents, and instructions live in Lola's
+`dev.getlola` extension namespace.
+
+## Initialize a Legacy AI Context Module
+
+```bash
+lola mod init my-module --format lola
+```
+
+This creates Lola's legacy AI Context Module structure:
 
 ```
 my-module/
@@ -23,9 +51,6 @@ my-module/
       example-agent.md
     mcps.json           # MCP settings
 ```
-
-!!! note
-    `lola mod init` currently creates only the AI Context Module pattern. Standalone Agent Skill initialization (`lola skill init`) is planned for a future release.
 
 ## Edit the skill
 

--- a/docs/guides/creating-modules.md
+++ b/docs/guides/creating-modules.md
@@ -1,6 +1,16 @@
 # Creating Modules
 
-Lola modules can be a single [Agent Skill](https://agentskills.io/specification) or a full [AI Context Module](../concepts/skills-and-modules.md). An Agent Skill is a standalone `SKILL.md` with optional supporting files. An AI Context Module is a superset - it wraps one or more skills alongside `AGENTS.md`, `commands/`, and `mcps.json` inside a `module/` directory.
+A Lola module can be an [Agent Plugins 1.0](https://agent-plugins.org/specification)
+package, a single [Agent Skill](https://agentskills.io/specification), or a
+legacy [AI Context Module](../concepts/skills-and-modules.md).
+
+An Agent Plugins package is the default `lola mod init` layout: a
+`plugin.json` manifest with portable `skills/` and `mcp.json` at the root,
+plus Lola's commands, agents, and instructions under the `dev.getlola`
+extension namespace. An Agent Skill is a standalone `SKILL.md` with optional
+supporting files. An AI Context Module is Lola's legacy layout - it wraps one
+or more skills alongside `AGENTS.md`, `commands/`, and `mcps.json` inside a
+`module/` directory, and now requires `lola mod init --format lola`.
 
 ## Initialize a Module
 

--- a/e2e/features/mod/add.feature
+++ b/e2e/features/mod/add.feature
@@ -14,3 +14,10 @@ Feature: Module registration
     And the module "my-module" is registered
     When I run lola "mod add {module_path}"
     Then the output should contain "already exists"
+
+  Scenario: Add an Agent Plugins package by its manifest name
+    Given an Agent Plugins package in "repository-name" named "manifest-name"
+    When I run lola "mod add {module_path}"
+    Then the exit code should be 0
+    And the output should contain "Added manifest-name"
+    And the directory "{lola_home}/modules/manifest-name" should exist

--- a/e2e/features/mod/init.feature
+++ b/e2e/features/mod/init.feature
@@ -7,9 +7,25 @@ Feature: Module initialization
     Then the exit code should be 0
     And the output should contain "Initialized module test-module"
     And the directory "{project}/test-module" should exist
+    And the file "{project}/test-module/plugin.json" should exist
 
   Scenario: Initialize a module when directory already exists
     When I run lola "mod init test-module"
     And I run lola "mod init test-module"
     Then the exit code should be 1
     And the output should contain "already exists"
+
+  Scenario: Initialize an Agent Plugins package by default
+    When I run lola "mod init portable-plugin"
+    Then the exit code should be 0
+    And the file "{project}/portable-plugin/plugin.json" should exist
+    And the file "{project}/portable-plugin/mcp.json" should exist
+    And the file "{project}/portable-plugin/skills/example-skill/SKILL.md" should exist
+    And the file "{project}/portable-plugin/dev.getlola/commands/example-command.md" should exist
+    And the file "{project}/portable-plugin/dev.getlola/agents/example-agent.md" should exist
+
+  Scenario: Initialize a legacy Lola module
+    When I run lola "mod init legacy-module --format lola"
+    Then the exit code should be 0
+    And the file "{project}/legacy-module/module/mcps.json" should exist
+    And the file "{project}/legacy-module/module/AGENTS.md" should exist

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -1,5 +1,6 @@
 """Step definitions for filesystem preconditions and assertions."""
 
+import json
 from pathlib import Path
 
 from behave import given, then
@@ -18,6 +19,28 @@ def step_module_full(context, name):
     source_dir.mkdir(exist_ok=True)
     module_path = create_module_full(source_dir, name)
     context.modules[name] = module_path
+
+
+@given('an Agent Plugins package in "{directory}" named "{name}"')
+def step_agent_plugin(context, directory, name):
+    """Create a portable plugin whose directory and manifest names differ."""
+    source_dir = context.tmp_dir / "sources" / directory
+    skill_dir = source_dir / "skills" / "skill1"
+    skill_dir.mkdir(parents=True)
+    (source_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "$schema": (
+                    "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+                ),
+                "name": name,
+            }
+        )
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: skill1\ndescription: Test skill\n---\n"
+    )
+    context.modules[name] = source_dir
 
 
 @given('the module "{name}" is registered')

--- a/src/lola/agent_plugin_scaffold.py
+++ b/src/lola/agent_plugin_scaffold.py
@@ -32,21 +32,42 @@ def plugin_name_from_directory(dirname: str) -> str:
     Directory names are not constrained the way manifest names are
     (``My_Project`` is a perfectly good folder), so slugify rather than
     reject when the name was inferred instead of typed.
+
+    Raises:
+        ValidationError: If nothing usable survives slugification.
     """
     slug = re.sub(r"[^a-z0-9.-]+", "-", dirname.lower())
     slug = re.sub(r"-{2,}", "-", slug)
     slug = re.sub(r"\.{2,}", ".", slug)
-    return slug.strip("-.")[:64].strip("-.")
+    slug = slug.strip("-.")[:64].strip("-.")
+    if not slug:
+        raise ValidationError(
+            dirname,
+            ["cannot derive a plugin name from this directory; pass a name"],
+        )
+    return slug
 
 
 def scaffold_agent_plugin(
     root: Path,
     name: str,
     options: ScaffoldOptions,
-) -> None:
-    """Create a conformant Agent Plugins package with Lola extensions."""
+) -> list[Path]:
+    """Create a conformant Agent Plugins package with Lola extensions.
+
+    Existing files are left alone and returned so the caller can report
+    them; re-running init must not clobber an edited package.
+    """
     if not validate_plugin_name(name):
         raise ValidationError(name, ["invalid Agent Plugins name"])
+
+    skipped: list[Path] = []
+
+    def write(path: Path, content: str) -> None:
+        if path.exists():
+            skipped.append(path)
+            return
+        path.write_text(content)
 
     root.mkdir(parents=True, exist_ok=True)
     extension = root / LOLA_NAMESPACE
@@ -70,44 +91,50 @@ def scaffold_agent_plugin(
             }
         },
     }
-    (root / "plugin.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    write(root / "plugin.json", json.dumps(manifest, indent=2) + "\n")
 
     if options.skill_name:
         skill = skills / options.skill_name
         skill.mkdir(exist_ok=True)
-        (skill / SKILL_FILE).write_text(
+        write(
+            skill / SKILL_FILE,
             "---\n"
             f"name: {options.skill_name}\n"
             "description: [REPLACE: Describe this skill and when to use it]\n"
             "---\n\n"
             f"# {_title_case(options.skill_name)}\n\n"
-            "[REPLACE: Skill instructions]\n"
+            "[REPLACE: Skill instructions]\n",
         )
     if options.command_name:
-        (commands / f"{options.command_name}.md").write_text(
+        write(
+            commands / f"{options.command_name}.md",
             "---\n"
             "description: [REPLACE: Describe this command]\n"
             "---\n\n"
-            "[REPLACE: Command instructions]\n"
+            "[REPLACE: Command instructions]\n",
         )
     if options.agent_name:
-        (agents / f"{options.agent_name}.md").write_text(
+        write(
+            agents / f"{options.agent_name}.md",
             "---\n"
             "description: [REPLACE: Describe this agent]\n"
             "---\n\n"
-            "[REPLACE: Agent instructions]\n"
+            "[REPLACE: Agent instructions]\n",
         )
     if options.include_mcps:
         mcp = {"$schema": MCP_SCHEMA, "mcpServers": {}}
-        (root / "mcp.json").write_text(json.dumps(mcp, indent=2) + "\n")
+        write(root / "mcp.json", json.dumps(mcp, indent=2) + "\n")
     if options.include_instructions:
-        (extension / "AGENTS.md").write_text(
+        write(
+            extension / "AGENTS.md",
             f"# {_title_case(name)}\n\n"
-            "[REPLACE: Instructions for agents using this plugin]\n"
+            "[REPLACE: Instructions for agents using this plugin]\n",
         )
-    (root / "README.md").write_text(
-        f"# {_title_case(name)}\n\n[REPLACE: Describe this Agent Plugins package]\n"
+    write(
+        root / "README.md",
+        f"# {_title_case(name)}\n\n[REPLACE: Describe this Agent Plugins package]\n",
     )
+    return skipped
 
 
 def _title_case(value: str) -> str:

--- a/src/lola/agent_plugin_scaffold.py
+++ b/src/lola/agent_plugin_scaffold.py
@@ -1,0 +1,114 @@
+"""Scaffolding for Agent Plugins v1 packages."""
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+
+from lola.agent_plugins import (
+    LOLA_NAMESPACE,
+    MCP_SCHEMA,
+    PLUGIN_SCHEMA,
+    validate_plugin_name,
+)
+from lola.config import SKILL_FILE
+from lola.exceptions import ValidationError
+
+
+@dataclass(frozen=True)
+class ScaffoldOptions:
+    """Options for an Agent Plugins scaffold."""
+
+    skill_name: str | None
+    command_name: str | None
+    agent_name: str | None
+    include_mcps: bool
+    include_instructions: bool
+
+
+def plugin_name_from_directory(dirname: str) -> str:
+    """Derive an Agent Plugins name from a directory name.
+
+    Directory names are not constrained the way manifest names are
+    (``My_Project`` is a perfectly good folder), so slugify rather than
+    reject when the name was inferred instead of typed.
+    """
+    slug = re.sub(r"[^a-z0-9.-]+", "-", dirname.lower())
+    slug = re.sub(r"-{2,}", "-", slug)
+    slug = re.sub(r"\.{2,}", ".", slug)
+    return slug.strip("-.")[:64].strip("-.")
+
+
+def scaffold_agent_plugin(
+    root: Path,
+    name: str,
+    options: ScaffoldOptions,
+) -> None:
+    """Create a conformant Agent Plugins package with Lola extensions."""
+    if not validate_plugin_name(name):
+        raise ValidationError(name, ["invalid Agent Plugins name"])
+
+    root.mkdir(parents=True, exist_ok=True)
+    extension = root / LOLA_NAMESPACE
+    skills = root / "skills"
+    commands = extension / "commands"
+    agents = extension / "agents"
+    skills.mkdir(exist_ok=True)
+    commands.mkdir(parents=True, exist_ok=True)
+    agents.mkdir(exist_ok=True)
+
+    manifest = {
+        "$schema": PLUGIN_SCHEMA,
+        "name": name,
+        "version": "0.1.0",
+        "description": "[REPLACE: Brief plugin description]",
+        "extensions": {
+            LOLA_NAMESPACE: {
+                "commands": f"./{LOLA_NAMESPACE}/commands",
+                "agents": f"./{LOLA_NAMESPACE}/agents",
+                "instructions": f"./{LOLA_NAMESPACE}/AGENTS.md",
+            }
+        },
+    }
+    (root / "plugin.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    if options.skill_name:
+        skill = skills / options.skill_name
+        skill.mkdir(exist_ok=True)
+        (skill / SKILL_FILE).write_text(
+            "---\n"
+            f"name: {options.skill_name}\n"
+            "description: [REPLACE: Describe this skill and when to use it]\n"
+            "---\n\n"
+            f"# {_title_case(options.skill_name)}\n\n"
+            "[REPLACE: Skill instructions]\n"
+        )
+    if options.command_name:
+        (commands / f"{options.command_name}.md").write_text(
+            "---\n"
+            "description: [REPLACE: Describe this command]\n"
+            "---\n\n"
+            "[REPLACE: Command instructions]\n"
+        )
+    if options.agent_name:
+        (agents / f"{options.agent_name}.md").write_text(
+            "---\n"
+            "description: [REPLACE: Describe this agent]\n"
+            "---\n\n"
+            "[REPLACE: Agent instructions]\n"
+        )
+    if options.include_mcps:
+        mcp = {"$schema": MCP_SCHEMA, "mcpServers": {}}
+        (root / "mcp.json").write_text(json.dumps(mcp, indent=2) + "\n")
+    if options.include_instructions:
+        (extension / "AGENTS.md").write_text(
+            f"# {_title_case(name)}\n\n"
+            "[REPLACE: Instructions for agents using this plugin]\n"
+        )
+    (root / "README.md").write_text(
+        f"# {_title_case(name)}\n\n[REPLACE: Describe this Agent Plugins package]\n"
+    )
+
+
+def _title_case(value: str) -> str:
+    return value.replace("-", " ").replace(".", " ").title()

--- a/src/lola/agent_plugins.py
+++ b/src/lola/agent_plugins.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import ipaddress
 import json
 from pathlib import Path
 import re
@@ -407,8 +408,12 @@ def _validate_stdio_server(root: Path, config: dict[object, object]) -> str | No
         or any(char.isspace() for char in command)
     ):
         return "command must be one executable token"
-    if command.startswith("./") and not _valid_package_path(root, command):
-        return "command is outside plugin root"
+    if command.startswith("./"):
+        if not _valid_package_path(root, command):
+            return "command is outside plugin root"
+    elif "/" in command or "\\" in command:
+        # v1 allows a bare executable name or a plugin-relative ./ path only.
+        return "command must be a bare name or a ./ plugin path"
     args = config.get("args", [])
     if not isinstance(args, list) or any(not isinstance(arg, str) for arg in args):
         return "args must be an array of strings"
@@ -429,12 +434,9 @@ def _validate_stdio_server(root: Path, config: dict[object, object]) -> str | No
 def _validate_remote_server(config: dict[object, object]) -> str | None:
     if set(config) - {"type", "url", "headers"}:
         return "unknown field"
-    url = config.get("url")
-    if not isinstance(url, str) or urlparse(url).scheme not in {
-        "http",
-        "https",
-    }:
-        return "url must use http or https"
+    url_error = _validate_remote_url(config.get("url"))
+    if url_error:
+        return url_error
     headers = config.get("headers", {})
     if not isinstance(headers, dict) or any(
         not isinstance(key, str) or not isinstance(value, str)
@@ -445,6 +447,28 @@ def _validate_remote_server(config: dict[object, object]) -> str | None:
     if any("${" in value for value in typed_headers.values()):
         return "headers cannot contain placeholders"
     return None
+
+
+def _validate_remote_url(url: object) -> str | None:
+    if not isinstance(url, str):
+        return "url must use http or https"
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return "url must be an absolute http or https URL"
+    if parsed.username or parsed.password or parsed.fragment:
+        return "url cannot contain userinfo or a fragment"
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname):
+        return "url must use https for non-loopback hosts"
+    return None
+
+
+def _is_loopback(host: str) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _valid_cwd(root: Path, value: str) -> bool:

--- a/src/lola/agent_plugins.py
+++ b/src/lola/agent_plugins.py
@@ -1,0 +1,470 @@
+"""Agent Plugins v1 package loading and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+from urllib.parse import urlparse
+from typing import cast
+
+from lola import config
+from lola import frontmatter as fm
+from lola.config import SKILL_FILE
+from lola.exceptions import ValidationError
+
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+LOLA_NAMESPACE = "dev.getlola"
+
+_PLUGIN_FIELDS = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
+_METADATA_STRING_FIELDS = {
+    "version",
+    "description",
+    "homepage",
+    "repository",
+    "license",
+}
+_CLIENT_NAMESPACES = (
+    "com.anthropic.claude",
+    "com.anthropic.claude-code",
+    "com.cursor.editor",
+    "com.github.copilot",
+    "com.google.gemini-cli",
+    "com.openai",
+    "com.openai.codex",
+    "ai.opencode",
+    LOLA_NAMESPACE,
+)
+_NAME_PATTERN = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")
+
+
+@dataclass
+class AgentPlugin:
+    """Normalized data discovered from an Agent Plugins package."""
+
+    name: str
+    skills: list[str] = field(default_factory=list)
+    command_paths: dict[str, Path] = field(default_factory=dict)
+    agent_paths: dict[str, Path] = field(default_factory=dict)
+    mcps_data: dict[str, dict[str, object]] = field(default_factory=dict)
+    instructions_path: Path | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def commands(self) -> list[str]:
+        """Return sorted command names."""
+        return sorted(self.command_paths)
+
+    @property
+    def agents(self) -> list[str]:
+        """Return sorted agent names."""
+        return sorted(self.agent_paths)
+
+    @property
+    def mcps(self) -> list[str]:
+        """Return sorted MCP server names."""
+        return sorted(self.mcps_data)
+
+
+def is_agent_plugin(root: Path) -> bool:
+    """Return whether a path declares an Agent Plugins manifest."""
+    return (root / "plugin.json").is_file()
+
+
+def validate_plugin_name(name: str) -> bool:
+    """Return whether a name satisfies Agent Plugins v1 constraints."""
+    return len(name) <= 64 and bool(_NAME_PATTERN.fullmatch(name))
+
+
+def load_agent_plugin(root: Path) -> AgentPlugin:
+    """Load and validate an Agent Plugins v1 package."""
+    manifest_path = root / "plugin.json"
+    manifest = _read_json_object(manifest_path, "plugin.json")
+    errors, warnings = _validate_manifest(manifest)
+    if errors:
+        raise ValidationError(root.name, errors)
+
+    name = cast(str, manifest["name"])
+    plugin = AgentPlugin(name=name, warnings=warnings)
+    plugin.skills = _discover_skills(root, plugin.warnings)
+
+    extensions = manifest.get("extensions")
+    if isinstance(extensions, dict):
+        typed_extensions = cast(dict[str, object], extensions)
+        _discover_extensions(root, typed_extensions, plugin)
+
+    mcp_path = root / "mcp.json"
+    if mcp_path.exists():
+        plugin.mcps_data = _load_mcps(root, mcp_path, plugin.warnings)
+    return plugin
+
+
+def materialize_module_mcps(
+    servers: dict[str, dict[str, object]],
+    plugin_root: Path,
+    module_name: str,
+    scope: str,
+    project_path: str | None,
+) -> dict[str, dict[str, object]]:
+    """Materialize a plugin's MCP servers with its data directory."""
+    if scope == "user":
+        plugin_data = config.LOLA_HOME / "plugin-data" / module_name
+    else:
+        plugin_data = Path(project_path or ".") / ".lola" / "plugin-data" / module_name
+    plugin_data.mkdir(parents=True, exist_ok=True)
+    return materialize_mcps(servers, plugin_root, plugin_data)
+
+
+def materialize_mcps(
+    servers: dict[str, dict[str, object]],
+    plugin_root: Path,
+    plugin_data: Path,
+) -> dict[str, dict[str, object]]:
+    """Translate portable MCP values to Lola's target-neutral shape."""
+    root_value = str(plugin_root.resolve())
+    data_value = str(plugin_data.resolve())
+    result: dict[str, dict[str, object]] = {}
+    for name, source in servers.items():
+        server = dict(source)
+        server_type = server.get("type")
+        if server_type == "stdio":
+            del server["type"]
+        elif server_type == "streamable-http":
+            server["type"] = "http"
+
+        command = server.get("command")
+        if isinstance(command, str):
+            if command.startswith("./"):
+                server["command"] = str(plugin_root / command[2:])
+            else:
+                server["command"] = _expand_plugin_value(
+                    command, root_value, data_value
+                )
+
+        values = server.get("args")
+        if isinstance(values, list):
+            server["args"] = [
+                _expand_plugin_value(cast(str, value), root_value, data_value)
+                for value in values
+            ]
+        env = server.get("env", {})
+        if server_type == "stdio" and isinstance(env, dict):
+            materialized_env = {
+                key: _expand_plugin_value(cast(str, value), root_value, data_value)
+                for key, value in env.items()
+            }
+            materialized_env["PLUGIN_ROOT"] = root_value
+            materialized_env["PLUGIN_DATA"] = data_value
+            server["env"] = materialized_env
+        cwd = server.get("cwd")
+        if isinstance(cwd, str):
+            if cwd.startswith("./"):
+                server["cwd"] = str(plugin_root / cwd[2:])
+            else:
+                server["cwd"] = _expand_plugin_value(cwd, root_value, data_value)
+        elif server_type == "stdio":
+            server["cwd"] = root_value
+        result[name] = server
+    return result
+
+
+def _expand_plugin_value(value: str, root: str, data: str) -> str:
+    return value.replace("${PLUGIN_ROOT}", root).replace("${PLUGIN_DATA}", data)
+
+
+def _read_json_object(path: Path, label: str) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as error:
+        raise ValidationError(path.parent.name, [f"{label}: {error}"]) from error
+    if not isinstance(data, dict):
+        raise ValidationError(
+            path.parent.name,
+            [f"{label}: expected a JSON object"],
+        )
+    return data
+
+
+def _validate_manifest(
+    manifest: dict[str, object],
+) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings = [
+        f"plugin.json: ignoring unknown field '{field}'"
+        for field in manifest
+        if field not in _PLUGIN_FIELDS
+    ]
+    if manifest.get("$schema") != PLUGIN_SCHEMA:
+        errors.append("plugin.json: unsupported or missing $schema")
+
+    name = manifest.get("name")
+    if not isinstance(name, str) or not validate_plugin_name(name):
+        errors.append("plugin.json: invalid name")
+
+    for field_name in _METADATA_STRING_FIELDS:
+        if field_name in manifest and not isinstance(manifest[field_name], str):
+            errors.append(f"plugin.json: {field_name} must be a string")
+
+    author = manifest.get("author")
+    if author is not None:
+        if not isinstance(author, dict):
+            errors.append("plugin.json: author must be an object")
+        else:
+            invalid = set(author) - {"name", "email", "url"}
+            if invalid or any(not isinstance(value, str) for value in author.values()):
+                errors.append("plugin.json: invalid author")
+
+    keywords = manifest.get("keywords")
+    if keywords is not None and (
+        not isinstance(keywords, list)
+        or any(not isinstance(value, str) for value in keywords)
+    ):
+        errors.append("plugin.json: keywords must be an array of strings")
+
+    extensions = manifest.get("extensions")
+    if isinstance(extensions, dict):
+        typed_extensions = cast(dict[str, object], extensions)
+        for namespace in _CLIENT_NAMESPACES:
+            value = typed_extensions.get(namespace)
+            if value is not None and not isinstance(value, dict):
+                warnings.append(
+                    f"plugin.json: ignoring invalid extension '{namespace}'"
+                )
+    elif extensions is not None:
+        warnings.append("plugin.json: ignoring non-object extensions")
+    return errors, warnings
+
+
+def _discover_skills(root: Path, warnings: list[str]) -> list[str]:
+    skills_root = root / "skills"
+    if not skills_root.exists():
+        return []
+    if not skills_root.is_dir() or not _is_contained(root, skills_root):
+        warnings.append("skills/: invalid or outside plugin root")
+        return []
+
+    skills: list[str] = []
+    for skill_dir in sorted(skills_root.iterdir()):
+        skill_file = skill_dir / SKILL_FILE
+        if not skill_dir.is_dir() or not skill_file.is_file():
+            continue
+        if not _is_contained(root, skill_file):
+            warnings.append(
+                f"skills/{skill_dir.name}/{SKILL_FILE}: outside plugin root"
+            )
+            continue
+        errors = fm.validate_skill(skill_file)
+        if errors:
+            warnings.append(
+                f"skills/{skill_dir.name}/{SKILL_FILE}: " + "; ".join(errors)
+            )
+            continue
+        skills.append(skill_dir.name)
+    return skills
+
+
+def _discover_extensions(
+    root: Path,
+    extensions: dict[str, object],
+    plugin: AgentPlugin,
+) -> None:
+    for namespace in _CLIENT_NAMESPACES:
+        config = extensions.get(namespace)
+        if not isinstance(config, dict):
+            typed_config: dict[str, object] = {}
+        else:
+            typed_config = cast(dict[str, object], config)
+        extension_root = root / namespace
+        for component, destination in (
+            ("commands", plugin.command_paths),
+            ("agents", plugin.agent_paths),
+        ):
+            configured = typed_config.get(component)
+            directory = _extension_path(
+                root,
+                configured,
+                extension_root / component,
+                f"extensions.{namespace}.{component}",
+                plugin.warnings,
+            )
+            if directory is None:
+                continue
+            for item in sorted(directory.glob("*.md")):
+                if item.is_file() and _is_contained(root, item):
+                    destination[item.stem] = item
+
+        configured_instructions = typed_config.get("instructions")
+        default_instructions = extension_root / "AGENTS.md"
+        instructions = _extension_path(
+            root,
+            configured_instructions,
+            default_instructions,
+            f"extensions.{namespace}.instructions",
+            plugin.warnings,
+            expect_directory=False,
+        )
+        if instructions is not None:
+            plugin.instructions_path = instructions
+
+
+def _extension_path(
+    root: Path,
+    configured: object,
+    default: Path,
+    label: str,
+    warnings: list[str],
+    *,
+    expect_directory: bool = True,
+) -> Path | None:
+    path = default
+    if configured is not None:
+        if not isinstance(configured, str) or not configured.startswith("./"):
+            warnings.append(f"{label}: expected a './' plugin-relative path")
+            return None
+        path = root / configured[2:]
+
+    exists_as_kind = path.is_dir() if expect_directory else path.is_file()
+    if not exists_as_kind:
+        return None
+    if not _is_contained(root, path):
+        warnings.append(f"{label}: outside plugin root")
+        return None
+    return path
+
+
+def _load_mcps(
+    root: Path,
+    path: Path,
+    warnings: list[str],
+) -> dict[str, dict[str, object]]:
+    if not path.is_file() or not _is_contained(root, path):
+        warnings.append("mcp.json: invalid or outside plugin root")
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as error:
+        warnings.append(f"mcp.json: {error}")
+        return {}
+    if not isinstance(data, dict):
+        warnings.append("mcp.json: expected a JSON object")
+        return {}
+    if data.get("$schema") != MCP_SCHEMA:
+        warnings.append("mcp.json: unsupported or missing $schema")
+        return {}
+    if set(data) != {"$schema", "mcpServers"}:
+        warnings.append("mcp.json: invalid top-level fields")
+        return {}
+    raw_servers = data.get("mcpServers")
+    if not isinstance(raw_servers, dict):
+        warnings.append("mcp.json: mcpServers must be an object")
+        return {}
+
+    servers: dict[str, dict[str, object]] = {}
+    for name, server in raw_servers.items():
+        validation_error = _validate_mcp_server(root, name, server)
+        if validation_error:
+            warnings.append(f"mcp.json: server '{name}': {validation_error}")
+            continue
+        servers[cast(str, name)] = dict(cast("dict[str, object]", server))
+    return servers
+
+
+def _validate_mcp_server(root: Path, name: object, config: object) -> str | None:
+    if not isinstance(name, str) or not name:
+        return "server name must be a non-empty string"
+    if not isinstance(config, dict):
+        return "configuration must be an object"
+    typed_config = cast(dict[object, object], config)
+    server_type = typed_config.get("type")
+    if server_type == "stdio":
+        return _validate_stdio_server(root, typed_config)
+    if server_type in {"streamable-http", "sse"}:
+        return _validate_remote_server(typed_config)
+    return "unsupported type"
+
+
+def _validate_stdio_server(root: Path, config: dict[object, object]) -> str | None:
+    allowed = {"type", "command", "args", "env", "cwd"}
+    if set(config) - allowed:
+        return "unknown field"
+    command = config.get("command")
+    if (
+        not isinstance(command, str)
+        or not command
+        or any(char.isspace() for char in command)
+    ):
+        return "command must be one executable token"
+    if command.startswith("./") and not _valid_package_path(root, command):
+        return "command is outside plugin root"
+    args = config.get("args", [])
+    if not isinstance(args, list) or any(not isinstance(arg, str) for arg in args):
+        return "args must be an array of strings"
+    env = config.get("env", {})
+    if not isinstance(env, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in env.items()
+    ):
+        return "env must contain string values"
+    if "PLUGIN_ROOT" in env or "PLUGIN_DATA" in env:
+        return "env contains a reserved variable"
+    cwd = config.get("cwd")
+    if cwd is not None and (not isinstance(cwd, str) or not _valid_cwd(root, cwd)):
+        return "invalid cwd"
+    return None
+
+
+def _validate_remote_server(config: dict[object, object]) -> str | None:
+    if set(config) - {"type", "url", "headers"}:
+        return "unknown field"
+    url = config.get("url")
+    if not isinstance(url, str) or urlparse(url).scheme not in {
+        "http",
+        "https",
+    }:
+        return "url must use http or https"
+    headers = config.get("headers", {})
+    if not isinstance(headers, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in headers.items()
+    ):
+        return "headers must contain literal string values"
+    typed_headers = cast(dict[str, str], headers)
+    if any("${" in value for value in typed_headers.values()):
+        return "headers cannot contain placeholders"
+    return None
+
+
+def _valid_cwd(root: Path, value: str) -> bool:
+    if value.startswith("./"):
+        return _valid_package_path(root, value)
+    return (
+        value == "${PLUGIN_ROOT}"
+        or value.startswith("${PLUGIN_ROOT}/")
+        or value == "${PLUGIN_DATA}"
+        or value.startswith("${PLUGIN_DATA}/")
+    )
+
+
+def _valid_package_path(root: Path, value: str) -> bool:
+    return _is_contained(root, root / value[2:])
+
+
+def _is_contained(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True

--- a/src/lola/agent_plugins.py
+++ b/src/lola/agent_plugins.py
@@ -149,7 +149,7 @@ def materialize_mcps(
         command = server.get("command")
         if isinstance(command, str):
             if command.startswith("./"):
-                server["command"] = str(plugin_root / command[2:])
+                server["command"] = str(plugin_root.resolve() / command[2:])
             else:
                 server["command"] = _expand_plugin_value(
                     command, root_value, data_value
@@ -173,7 +173,7 @@ def materialize_mcps(
         cwd = server.get("cwd")
         if isinstance(cwd, str):
             if cwd.startswith("./"):
-                server["cwd"] = str(plugin_root / cwd[2:])
+                server["cwd"] = str(plugin_root.resolve() / cwd[2:])
             else:
                 server["cwd"] = _expand_plugin_value(cwd, root_value, data_value)
         elif server_type == "stdio":
@@ -259,6 +259,8 @@ def _discover_skills(root: Path, warnings: list[str]) -> list[str]:
 
     skills: list[str] = []
     for skill_dir in sorted(skills_root.iterdir()):
+        if skill_dir.name.startswith("."):
+            continue
         skill_file = skill_dir / SKILL_FILE
         if not skill_dir.is_dir() or not skill_file.is_file():
             continue

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -473,11 +473,10 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     command_dest = ctx.target.get_command_path(path_context, scope)
     if command_dest is None:
         return 0, 0
-    content_path = _get_content_path(ctx.source_module)
-    commands_dir = content_path / "commands"
-
-    for cmd_name in ctx.global_module.commands:
-        source = commands_dir / f"{cmd_name}.md"
+    for cmd_name, source in zip(
+        ctx.global_module.commands,
+        ctx.global_module.get_command_paths_from(ctx.source_module),
+    ):
         success = ctx.target.generate_command(
             source, command_dest, cmd_name, ctx.inst.module_name
         )
@@ -514,10 +513,10 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     agents_ok = 0
     agents_failed = 0
 
-    content_path = _get_content_path(ctx.source_module)
-    agents_dir = content_path / "agents"
-    for agent_name in ctx.global_module.agents:
-        source = agents_dir / f"{agent_name}.md"
+    for agent_name, source in zip(
+        ctx.global_module.agents,
+        ctx.global_module.get_agent_paths_from(ctx.source_module),
+    ):
         success = ctx.target.generate_agent(
             source, agent_dest, agent_name, ctx.inst.module_name
         )
@@ -542,7 +541,6 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
 
     Returns True if instructions were successfully installed.
     """
-    from lola.models import INSTRUCTIONS_FILE
 
     path_context = ctx.inst.project_path or ""
     scope = ctx.inst.scope
@@ -573,8 +571,9 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
             console.print("      [green]instructions (appended)[/green]")
         return success
 
-    content_path = _get_content_path(ctx.source_module)
-    instructions_source = content_path / INSTRUCTIONS_FILE
+    instructions_source = ctx.global_module.get_instructions_path_from(
+        ctx.source_module
+    )
     if not instructions_source.exists():
         return False
 
@@ -606,17 +605,28 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not mcp_dest:
         return 0, 0
 
-    # Load mcps.json from source module (respecting module/ subdirectory)
-    content_path = _get_content_path(ctx.source_module)
-    mcps_file = content_path / MCPS_FILE
-    if not mcps_file.exists():
-        return 0, len(ctx.global_module.mcps)
+    if ctx.global_module.mcps_data:
+        from lola.agent_plugins import materialize_module_mcps
 
-    try:
-        mcps_data = json.loads(mcps_file.read_text())
-        servers = mcps_data.get("mcpServers", {})
-    except json.JSONDecodeError:
-        return 0, len(ctx.global_module.mcps)
+        servers = materialize_module_mcps(
+            ctx.global_module.mcps_data,
+            ctx.source_module,
+            ctx.inst.module_name,
+            scope,
+            ctx.inst.project_path,
+        )
+    else:
+        # Load mcps.json from source module (respecting module/ subdirectory)
+        content_path = _get_content_path(ctx.source_module)
+        mcps_file = content_path / MCPS_FILE
+        if not mcps_file.exists():
+            return 0, len(ctx.global_module.mcps)
+
+        try:
+            mcps_data = json.loads(mcps_file.read_text())
+            servers = mcps_data.get("mcpServers", {})
+        except json.JSONDecodeError:
+            return 0, len(ctx.global_module.mcps)
 
     # Generate MCPs
     if ctx.target.generate_mcps(servers, mcp_dest, ctx.inst.module_name):

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -266,6 +266,9 @@ def add_module(
     try:
         module = Module.from_path(module_path, module_content_dirname)
     except LolaError as error:
+        # A malformed plugin.json leaves an unregistered directory behind.
+        if module_path.exists():
+            shutil.rmtree(module_path)
         handle_lola_error(error)
     if not module:
         error_msg = "[yellow]No skills or commands found[/yellow]"
@@ -294,6 +297,12 @@ def add_module(
         if new_path.exists():
             console.print()
             console.print(f"[yellow]Module '{module.name}' already exists.[/yellow]")
+            if not is_interactive():
+                shutil.rmtree(module.path)
+                console.print(
+                    "[red]Cannot confirm overwrite in non-interactive mode[/red]"
+                )
+                raise SystemExit(1)
             if not click.confirm("Overwrite existing module?", default=False):
                 shutil.rmtree(module.path)
                 console.print("[yellow]Cancelled[/yellow]")
@@ -424,6 +433,14 @@ def init_module(
         lola mod init --no-mcps                 # Skip creating mcp.json
         lola mod init --no-instructions         # Skip creating AGENTS.md
     """
+    # The name becomes a path component below, so reject traversal before
+    # any directory is resolved or removed.
+    if name:
+        try:
+            name = validate_module_name(name)
+        except ModuleNameError as error:
+            handle_lola_error(error)
+
     if format_name == "agent-plugins":
         from lola.agent_plugin_scaffold import (
             ScaffoldOptions,
@@ -432,7 +449,10 @@ def init_module(
         )
 
         repo_dir = Path.cwd() / name if name else Path.cwd()
-        module_name = name or plugin_name_from_directory(repo_dir.name)
+        try:
+            module_name = name or plugin_name_from_directory(repo_dir.name)
+        except LolaError as error:
+            handle_lola_error(error)
         if name and repo_dir.exists():
             if force:
                 shutil.rmtree(repo_dir)
@@ -445,10 +465,13 @@ def init_module(
             include_mcps=not (minimal or no_mcps),
             include_instructions=not (minimal or no_instructions),
         )
+        skipped: list[Path] = []
         try:
-            scaffold_agent_plugin(repo_dir, module_name, options)
+            skipped = scaffold_agent_plugin(repo_dir, module_name, options)
         except LolaError as error:
             handle_lola_error(error)
+        for existing in skipped:
+            console.print(f"[yellow]File already exists, skipping:[/yellow] {existing}")
         console.print(f"[green]Initialized module {module_name}[/green]")
         console.print(f"  [dim]Path:[/dim] {repo_dir}")
         return

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -12,6 +12,7 @@ import click
 from rich.console import Console
 from rich.tree import Tree
 
+from lola.agent_plugins import is_agent_plugin
 from lola.cli.completions import complete_module_names
 from lola.config import MCPS_FILE, MODULES_DIR, INSTALLED_FILE
 from lola.exceptions import (
@@ -54,7 +55,10 @@ def load_registered_module(module_path: Path) -> Optional[Module]:
     """
     source_info = load_source_info(module_path)
     content_dirname = source_info.get("content_dirname") if source_info else None
-    return Module.from_path(module_path, content_dirname)
+    try:
+        return Module.from_path(module_path, content_dirname)
+    except LolaError:
+        return None
 
 
 def list_registered_modules() -> list[Module]:
@@ -241,7 +245,8 @@ def add_module(
         raise SystemExit(1)
 
     # Rename if name override provided
-    if module_name and module_path.name != module_name:
+    is_plugin = is_agent_plugin(module_path)
+    if module_name and module_path.name != module_name and not is_plugin:
         # Validate the provided module name to prevent directory traversal
         try:
             module_name = validate_module_name(module_name)
@@ -258,7 +263,10 @@ def add_module(
         module_path = new_path
 
     # Validate module structure
-    module = Module.from_path(module_path, module_content_dirname)
+    try:
+        module = Module.from_path(module_path, module_content_dirname)
+    except LolaError as error:
+        handle_lola_error(error)
     if not module:
         error_msg = "[yellow]No skills or commands found[/yellow]"
         if module_content_dirname:
@@ -270,6 +278,35 @@ def add_module(
             "[dim]Add skill folders with SKILL.md or commands/*.md files[/dim]"
         )
         return
+
+    # Agent Plugins declare their identity in plugin.json. Align the registry
+    # directory unless the user explicitly selected an identity with --name.
+    if is_plugin and module_name and module_name != module.name:
+        shutil.rmtree(module.path)
+        handle_lola_error(
+            ModuleNameError(
+                module_name,
+                "Agent Plugins use plugin.json.name as their identity",
+            )
+        )
+    if is_plugin and module.path.name != module.name:
+        new_path = MODULES_DIR / validate_module_name(module.name)
+        if new_path.exists():
+            console.print()
+            console.print(f"[yellow]Module '{module.name}' already exists.[/yellow]")
+            if not click.confirm("Overwrite existing module?", default=False):
+                shutil.rmtree(module.path)
+                console.print("[yellow]Cancelled[/yellow]")
+                return
+            shutil.rmtree(new_path)
+        module.path.rename(new_path)
+        module_path = new_path
+        module = Module.from_path(module_path, module_content_dirname)
+        if module is None:
+            raise SystemExit(1)
+
+    for warning in module.format_warnings:
+        console.print(f"[yellow]{warning}[/yellow]")
 
     is_valid, errors = module.validate()
     if not is_valid:
@@ -338,6 +375,14 @@ def add_module(
 @click.option(
     "--minimal", is_flag=True, help="Create only empty directories, no example content"
 )
+@click.option(
+    "--format",
+    "format_name",
+    type=click.Choice(["agent-plugins", "lola"]),
+    default="agent-plugins",
+    show_default=True,
+    help="Package format to create",
+)
 @click.option("--force", is_flag=True, help="Overwrite existing directory")
 def init_module(
     name: str | None,
@@ -350,32 +395,64 @@ def init_module(
     no_mcps: bool,
     no_instructions: bool,
     minimal: bool,
+    format_name: str,
     force: bool,
 ):
     """
-    Initialize a new lola module.
+    Initialize a new module.
 
-    Creates a module folder structure with a module/ subdirectory containing
-    skills, commands, agents, mcps.json, and AGENTS.md. A README.md is created
-    at the repository root.
+    By default, creates an Agent Plugins 1.0 package: plugin.json, portable
+    skills/ and mcp.json at the root, plus Lola's commands, agents, and
+    AGENTS.md under the dev.getlola/ extension namespace. Use --format lola
+    for the legacy layout with a module/ subdirectory.
 
-    By default, creates example content in the module/ directory. Use --minimal
-    to create only empty directories, or use --no-skill, --no-command, --no-agent,
-    --no-mcps, or --no-instructions to skip specific components.
+    By default, creates example content. Use --minimal to create only empty
+    directories, or use --no-skill, --no-command, --no-agent, --no-mcps, or
+    --no-instructions to skip specific components.
 
     \b
     Examples:
         lola mod init                           # Use current folder name
         lola mod init my-skills                 # Create my-skills/ subdirectory
+        lola mod init --format lola             # Legacy module/ layout
         lola mod init --minimal                 # Empty structure, no example content
         lola mod init --force                   # Overwrite existing directory
         lola mod init -s code-review            # Custom skill name
         lola mod init --no-skill                # Skip initial skill
         lola mod init -c review-pr              # Custom command name
         lola mod init -g my-agent               # Custom agent name
-        lola mod init --no-mcps                 # Skip creating mcps.json
+        lola mod init --no-mcps                 # Skip creating mcp.json
         lola mod init --no-instructions         # Skip creating AGENTS.md
     """
+    if format_name == "agent-plugins":
+        from lola.agent_plugin_scaffold import (
+            ScaffoldOptions,
+            plugin_name_from_directory,
+            scaffold_agent_plugin,
+        )
+
+        repo_dir = Path.cwd() / name if name else Path.cwd()
+        module_name = name or plugin_name_from_directory(repo_dir.name)
+        if name and repo_dir.exists():
+            if force:
+                shutil.rmtree(repo_dir)
+            else:
+                handle_lola_error(PathExistsError(repo_dir, "Directory"))
+        options = ScaffoldOptions(
+            skill_name=None if minimal or no_skill else skill_name,
+            command_name=None if minimal or no_command else command_name,
+            agent_name=None if minimal or no_agent else agent_name,
+            include_mcps=not (minimal or no_mcps),
+            include_instructions=not (minimal or no_instructions),
+        )
+        try:
+            scaffold_agent_plugin(repo_dir, module_name, options)
+        except LolaError as error:
+            handle_lola_error(error)
+        console.print(f"[green]Initialized module {module_name}[/green]")
+        console.print(f"  [dim]Path:[/dim] {repo_dir}")
+        return
+
     if name:
         # Create a new subdirectory
         repo_dir = Path.cwd() / name
@@ -946,7 +1023,10 @@ def module_info(module_name_or_path: str | None):
         if not module_path.is_dir():
             console.print(f"[red]Not a directory: {module_name_or_path}[/red]")
             raise SystemExit(1)
-        module = Module.from_path(module_path)
+        try:
+            module = Module.from_path(module_path)
+        except LolaError as error:
+            handle_lola_error(error)
     else:
         # Treat as a registered module name (load with content_dirname)
         module_path = MODULES_DIR / module_name_or_path
@@ -1033,8 +1113,8 @@ def module_info(module_name_or_path: str | None):
         from lola.config import MCPS_FILE
 
         mcps_file = module.path / MCPS_FILE
-        mcps_data = {}
-        if mcps_file.exists():
+        mcps_data = dict(module.mcps_data)
+        if not mcps_data and mcps_file.exists():
             try:
                 mcps_data = json.loads(mcps_file.read_text()).get("mcpServers", {})
             except (json.JSONDecodeError, OSError):
@@ -1044,7 +1124,8 @@ def module_info(module_name_or_path: str | None):
             console.print(f"  [green]{mcp_name}[/green]")
             mcp_info = mcps_data.get(mcp_name, {})
             cmd = mcp_info.get("command", "")
-            args = mcp_info.get("args", [])
+            raw_args = mcp_info.get("args", [])
+            args = [str(a) for a in raw_args] if isinstance(raw_args, list) else []
             if cmd:
                 cmd_str = f"{cmd} {' '.join(args[:2])}"
                 if len(args) > 2:

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -143,6 +143,11 @@ class Module:
     commands: list[str] = field(default_factory=list)
     agents: list[str] = field(default_factory=list)
     mcps: list[str] = field(default_factory=list)
+    command_paths: dict[str, Path] = field(default_factory=dict)
+    agent_paths: dict[str, Path] = field(default_factory=dict)
+    instructions_path: Path | None = None
+    mcps_data: dict[str, dict[str, object]] = field(default_factory=dict)
+    format_warnings: list[str] = field(default_factory=list)
     has_instructions: bool = False
     uses_module_subdir: bool = False  # True if content is in module/ subdirectory
     is_single_skill: bool = (
@@ -174,6 +179,36 @@ class Module:
         """
         if not module_path.exists() or not module_path.is_dir():
             return None
+
+        from lola.agent_plugins import is_agent_plugin, load_agent_plugin
+
+        if content_dirname in (None, "/") and is_agent_plugin(module_path):
+            plugin = load_agent_plugin(module_path)
+            # Same emptiness rule as the native path below: a package with
+            # nothing installable is not a module.
+            if not (
+                plugin.skills
+                or plugin.command_paths
+                or plugin.agent_paths
+                or plugin.mcps_data
+                or plugin.instructions_path
+            ):
+                return None
+            return cls(
+                name=plugin.name,
+                path=module_path,
+                content_path=module_path,
+                skills=plugin.skills,
+                commands=plugin.commands,
+                agents=plugin.agents,
+                mcps=plugin.mcps,
+                command_paths=plugin.command_paths,
+                agent_paths=plugin.agent_paths,
+                instructions_path=plugin.instructions_path,
+                mcps_data=plugin.mcps_data,
+                format_warnings=plugin.warnings,
+                has_instructions=plugin.instructions_path is not None,
+            )
 
         content_path, uses_module_subdir = cls._resolve_content_path(
             module_path, content_dirname
@@ -330,13 +365,35 @@ class Module:
 
     def get_command_paths(self) -> list[Path]:
         """Get the full paths to all commands in this module."""
+        if self.command_paths:
+            return [self.command_paths[name] for name in self.commands]
         commands_dir = self.content_path / "commands"
         return [commands_dir / f"{cmd}.md" for cmd in self.commands]
 
+    def get_command_paths_from(self, module_path: Path) -> list[Path]:
+        """Get command paths rebased onto another copy of the module."""
+        return [
+            module_path / path.relative_to(self.path)
+            for path in self.get_command_paths()
+        ]
+
     def get_agent_paths(self) -> list[Path]:
         """Get the full paths to all agents in this module."""
+        if self.agent_paths:
+            return [self.agent_paths[name] for name in self.agents]
         agents_dir = self.content_path / "agents"
         return [agents_dir / f"{agent}.md" for agent in self.agents]
+
+    def get_agent_paths_from(self, module_path: Path) -> list[Path]:
+        """Get agent paths rebased onto another copy of the module."""
+        return [
+            module_path / path.relative_to(self.path) for path in self.get_agent_paths()
+        ]
+
+    def get_instructions_path_from(self, module_path: Path) -> Path:
+        """Get the instructions path rebased onto another module copy."""
+        source = self.instructions_path or self.content_path / INSTRUCTIONS_FILE
+        return module_path / source.relative_to(self.path)
 
     def validate(self) -> tuple[bool, list[str]]:
         """
@@ -360,9 +417,7 @@ class Module:
                     errors.append(f"{skill_name}/{SKILL_FILE}: {err}")
 
         # Check each command exists and has valid frontmatter
-        commands_dir = self.content_path / "commands"
-        for cmd_name in self.commands:
-            cmd_path = commands_dir / f"{cmd_name}.md"
+        for cmd_name, cmd_path in zip(self.commands, self.get_command_paths()):
             if not cmd_path.exists():
                 errors.append(f"Command file not found: commands/{cmd_name}.md")
             else:
@@ -371,9 +426,7 @@ class Module:
                     errors.append(f"commands/{cmd_name}.md: {err}")
 
         # Check each agent exists and has valid frontmatter
-        agents_dir = self.content_path / "agents"
-        for agent_name in self.agents:
-            agent_path = agents_dir / f"{agent_name}.md"
+        for agent_name, agent_path in zip(self.agents, self.get_agent_paths()):
             if not agent_path.exists():
                 errors.append(f"Agent file not found: agents/{agent_name}.md")
             else:
@@ -382,7 +435,7 @@ class Module:
                     errors.append(f"agents/{agent_name}.md: {err}")
 
         # Check mcps.json if module has MCPs
-        if self.mcps:
+        if self.mcps and not self.mcps_data:
             mcps_file = self.content_path / MCPS_FILE
             if not mcps_file.exists():
                 errors.append(f"MCP file not found: {MCPS_FILE}")

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -182,8 +182,22 @@ class Module:
 
         from lola.agent_plugins import is_agent_plugin, load_agent_plugin
 
-        if content_dirname in (None, "/") and is_agent_plugin(module_path):
-            plugin = load_agent_plugin(module_path)
+        content_path, uses_module_subdir = cls._resolve_content_path(
+            module_path, content_dirname
+        )
+
+        if content_path is None:
+            return None
+
+        # A plugin package can sit at the module root or in the
+        # subdirectory selected by a marketplace path / --module-content.
+        plugin_root = (
+            module_path
+            if content_dirname is None and is_agent_plugin(module_path)
+            else content_path
+        )
+        if is_agent_plugin(plugin_root):
+            plugin = load_agent_plugin(plugin_root)
             # Same emptiness rule as the native path below: a package with
             # nothing installable is not a module.
             if not (
@@ -197,7 +211,7 @@ class Module:
             return cls(
                 name=plugin.name,
                 path=module_path,
-                content_path=module_path,
+                content_path=plugin_root,
                 skills=plugin.skills,
                 commands=plugin.commands,
                 agents=plugin.agents,
@@ -209,13 +223,6 @@ class Module:
                 format_warnings=plugin.warnings,
                 has_instructions=plugin.instructions_path is not None,
             )
-
-        content_path, uses_module_subdir = cls._resolve_content_path(
-            module_path, content_dirname
-        )
-
-        if content_path is None:
-            return None
 
         skills = []
         is_single_skill = False

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -221,7 +221,12 @@ class Module:
                 instructions_path=plugin.instructions_path,
                 mcps_data=plugin.mcps_data,
                 format_warnings=plugin.warnings,
-                has_instructions=plugin.instructions_path is not None,
+                # Same rule as the legacy branch: an empty file is no
+                # instructions at all.
+                has_instructions=(
+                    plugin.instructions_path is not None
+                    and plugin.instructions_path.stat().st_size > 0
+                ),
             )
 
         skills = []

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -89,6 +89,20 @@ def validate_module_name(name: str) -> str:
     return name
 
 
+def _find_plugin_root(root: Path) -> Optional[Path]:
+    """Return the shallowest directory holding an Agent Plugins manifest.
+
+    Agent Plugins packages keep their commands/agents under a client
+    namespace directory (``dev.getlola/commands``), so the SKILL.md and
+    ``commands/`` heuristics below would otherwise select the namespace
+    directory and drop ``plugin.json`` and ``skills/`` on the floor.
+    """
+    roots = [path.parent for path in root.rglob("plugin.json") if path.is_file()]
+    if not roots:
+        return None
+    return min(roots, key=lambda path: len(path.parts))
+
+
 class SourceHandler(ABC):
     """Base class for module source handlers."""
 
@@ -241,6 +255,10 @@ class ZipSourceHandler(SourceHandler):
         return module_dir
 
     def _find_module_dir(self, root: Path) -> Optional[Path]:
+        plugin_root = _find_plugin_root(root)
+        if plugin_root is not None:
+            return plugin_root
+
         for path in root.rglob(SKILL_FILE):
             skill_dir = path.parent
             maybe_skills_dir = skill_dir.parent
@@ -321,6 +339,10 @@ class TarSourceHandler(SourceHandler):
         return module_dir
 
     def _find_module_dir(self, root: Path) -> Optional[Path]:
+        plugin_root = _find_plugin_root(root)
+        if plugin_root is not None:
+            return plugin_root
+
         for path in root.rglob(SKILL_FILE):
             skill_dir = path.parent
             maybe_skills_dir = skill_dir.parent
@@ -553,6 +575,10 @@ class FolderSourceHandler(SourceHandler):
     ) -> Optional[Path]:
         """Locate the module subtree by scanning for SKILL.md or commands/*.md."""
         candidates = self._candidate_files(source_path, kept)
+        # An Agent Plugins manifest marks its own package root.
+        plugin_rels = [rel.parent for rel in candidates if rel.name == "plugin.json"]
+        if plugin_rels:
+            return source_path / min(plugin_rels, key=lambda rel: len(rel.parts))
         # Prefer SKILL.md
         for rel in candidates:
             if rel.name == SKILL_FILE:

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -337,11 +337,9 @@ def _install_commands(
         )
         return [], []
 
-    content_dirname = _get_content_dirname(module)
-    content_path = _get_content_path(local_module_path, content_dirname)
-    commands_dir = content_path / "commands"
-    for cmd in module.commands:
-        source = commands_dir / f"{cmd}.md"
+    for cmd, source in zip(
+        module.commands, module.get_command_paths_from(local_module_path)
+    ):
         effective_cmd = cmd
 
         dest_file = command_dest / target.get_command_filename(module.name, cmd)
@@ -391,11 +389,9 @@ def _install_agents(
     installed: list[str] = []
     failed: list[str] = []
 
-    content_dirname = _get_content_dirname(module)
-    content_path = _get_content_path(local_module_path, content_dirname)
-    agents_dir = content_path / "agents"
-    for agent in module.agents:
-        source = agents_dir / f"{agent}.md"
+    for agent, source in zip(
+        module.agents, module.get_agent_paths_from(local_module_path)
+    ):
         effective_agent = agent
 
         dest_file = agent_dest / target.get_agent_filename(module.name, agent)
@@ -434,7 +430,6 @@ def _install_instructions(
     scope: str = "project",
 ) -> bool:
     """Install module instructions for a target. Returns True if installed."""
-    from lola.models import INSTRUCTIONS_FILE
 
     if not module.has_instructions:
         return False
@@ -501,9 +496,7 @@ def _install_instructions(
     if not module.has_instructions:
         return False
 
-    content_dirname = _get_content_dirname(module)
-    content_path = _get_content_path(local_module_path, content_dirname)
-    instructions_source = content_path / INSTRUCTIONS_FILE
+    instructions_source = module.get_instructions_path_from(local_module_path)
     if not instructions_source.exists():
         return False
 
@@ -533,6 +526,16 @@ def _install_mcps(
             f"https://github.com/LobsterTrap/lola[/yellow]"
         )
         return [], []
+
+    if module.mcps_data:
+        from lola.agent_plugins import materialize_module_mcps
+
+        servers = materialize_module_mcps(
+            module.mcps_data, local_module_path, module.name, scope, project_path
+        )
+        if target.generate_mcps(servers, mcp_dest, module.name):
+            return list(servers), []
+        return [], list(module.mcps)
 
     # Load mcps.json from local module (respecting module/ subdirectory)
     content_dirname = _get_content_dirname(module)

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -72,6 +72,31 @@ def test_module_loads_plugin_from_content_dirname(tmp_path: Path) -> None:
     assert module.content_path == nested
 
 
+def test_skips_hidden_skill_directories(tmp_path: Path) -> None:
+    """Dot-prefixed directories are not skills, matching the legacy loader."""
+    _write_manifest(tmp_path)
+    _write_skill(tmp_path, "review")
+    _write_skill(tmp_path, ".cache")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.skills == ["review"]
+
+
+def test_empty_instructions_file_is_not_instructions(tmp_path: Path) -> None:
+    """A zero-byte AGENTS.md must not install an empty block."""
+    _write_manifest(tmp_path)
+    _write_skill(tmp_path, "review")
+    extension = tmp_path / "dev.getlola"
+    extension.mkdir()
+    (extension / "AGENTS.md").write_text("")
+
+    module = Module.from_path(tmp_path)
+
+    assert module is not None
+    assert module.has_instructions is False
+
+
 def test_loopback_http_mcp_url_is_allowed(tmp_path: Path) -> None:
     """Plain HTTP is portable only for loopback hosts."""
     _write_manifest(tmp_path)
@@ -207,18 +232,20 @@ def test_ignores_unknown_manifest_fields_with_warning(tmp_path: Path) -> None:
 
 def test_rejects_extension_path_outside_plugin(tmp_path: Path) -> None:
     """Extension paths cannot escape the plugin root through symlinks."""
-    outside = tmp_path.parent / "outside-commands"
+    root = tmp_path / "plugin"
+    root.mkdir()
+    outside = tmp_path / "outside-commands"
     outside.mkdir()
     (outside / "bad.md").write_text("# Bad")
-    (tmp_path / "escape").symlink_to(outside, target_is_directory=True)
+    (root / "escape").symlink_to(outside, target_is_directory=True)
     _write_manifest(
-        tmp_path,
+        root,
         extensions={
             "dev.getlola": {"commands": "./escape"},
         },
     )
 
-    plugin = load_agent_plugin(tmp_path)
+    plugin = load_agent_plugin(root)
 
     assert plugin.commands == []
     assert "outside plugin root" in plugin.warnings[0]

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -1,0 +1,568 @@
+"""Tests for Agent Plugins v1 package support."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lola.agent_plugins import (
+    MCP_SCHEMA,
+    PLUGIN_SCHEMA,
+    load_agent_plugin,
+    materialize_mcps,
+)
+from lola.agent_plugin_scaffold import ScaffoldOptions, scaffold_agent_plugin
+from lola.cli.install import install_cmd, update_cmd
+from lola.exceptions import ValidationError
+from lola.models import Module
+
+
+def _write_manifest(root: Path, **overrides: object) -> None:
+    manifest = {
+        "$schema": PLUGIN_SCHEMA,
+        "name": "portable-plugin",
+    }
+    manifest.update(overrides)
+    (root / "plugin.json").write_text(json.dumps(manifest))
+
+
+def _write_skill(root: Path, name: str) -> Path:
+    skill = root / "skills" / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test skill\n---\n"
+    )
+    return skill
+
+
+def test_loads_portable_core_and_manifest_name(tmp_path: Path) -> None:
+    """Discover skills and MCP servers from their fixed v1 locations."""
+    _write_manifest(tmp_path)
+    _write_skill(tmp_path, "review")
+    mcp = {
+        "$schema": MCP_SCHEMA,
+        "mcpServers": {
+            "reviewer": {
+                "type": "stdio",
+                "command": "uvx",
+                "args": ["review", "${PLUGIN_ROOT}/rules.json"],
+            }
+        },
+    }
+    (tmp_path / "mcp.json").write_text(json.dumps(mcp))
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.name == "portable-plugin"
+    assert plugin.skills == ["review"]
+    assert plugin.mcps == ["reviewer"]
+
+
+def test_module_reads_lola_namespace(tmp_path: Path) -> None:
+    """Lola extensions provide non-portable commands and agents."""
+    _write_manifest(
+        tmp_path,
+        extensions={
+            "dev.getlola": {
+                "commands": "./dev.getlola/commands",
+                "agents": "./dev.getlola/agents",
+                "instructions": "./dev.getlola/AGENTS.md",
+            }
+        },
+    )
+    _write_skill(tmp_path, "review")
+    extension = tmp_path / "dev.getlola"
+    (extension / "commands").mkdir(parents=True)
+    (extension / "agents").mkdir()
+    (extension / "commands" / "check.md").write_text(
+        "---\ndescription: Check code\n---\n"
+    )
+    (extension / "agents" / "reviewer.md").write_text(
+        "---\ndescription: Review code\n---\n"
+    )
+    (extension / "AGENTS.md").write_text("# Instructions\n")
+
+    module = Module.from_path(tmp_path)
+
+    assert module is not None
+    assert module.name == "portable-plugin"
+    assert module.commands == ["check"]
+    assert module.agents == ["reviewer"]
+    assert module.get_command_paths() == [extension / "commands" / "check.md"]
+    assert module.get_agent_paths() == [extension / "agents" / "reviewer.md"]
+    assert module.instructions_path == extension / "AGENTS.md"
+
+
+def test_reads_known_client_namespace_paths(tmp_path: Path) -> None:
+    """Known client extension paths are translated through Lola."""
+    _write_manifest(
+        tmp_path,
+        extensions={
+            "com.anthropic.claude-code": {
+                "commands": "./claude/commands",
+                "agents": "./claude/agents",
+            }
+        },
+    )
+    (tmp_path / "claude" / "commands").mkdir(parents=True)
+    (tmp_path / "claude" / "agents").mkdir()
+    (tmp_path / "claude" / "commands" / "deploy.md").write_text("# Deploy")
+    (tmp_path / "claude" / "agents" / "ops.md").write_text("# Ops")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.commands == ["deploy"]
+    assert plugin.agents == ["ops"]
+
+
+def test_lola_namespace_wins_duplicate_component_names(tmp_path: Path) -> None:
+    """The Lola-owned namespace has deterministic precedence."""
+    _write_manifest(
+        tmp_path,
+        extensions={
+            "com.anthropic.claude-code": {
+                "commands": "./claude/commands",
+            },
+            "dev.getlola": {
+                "commands": "./dev.getlola/commands",
+            },
+        },
+    )
+    for directory in ("claude", "dev.getlola"):
+        commands = tmp_path / directory / "commands"
+        commands.mkdir(parents=True)
+        (commands / "review.md").write_text(f"# {directory}")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.command_paths["review"] == (
+        tmp_path / "dev.getlola" / "commands" / "review.md"
+    )
+
+
+@pytest.mark.parametrize(
+    ("manifest", "message"),
+    [
+        ({"name": "valid-name"}, r"unsupported or missing \$schema"),
+        ({"$schema": PLUGIN_SCHEMA, "name": "Bad Name"}, "invalid name"),
+        ({"$schema": PLUGIN_SCHEMA, "name": "ok", "version": 1}, "version"),
+    ],
+)
+def test_rejects_invalid_manifest(
+    tmp_path: Path, manifest: dict[str, object], message: str
+) -> None:
+    """Fatal manifest schema violations reject the entire plugin."""
+    (tmp_path / "plugin.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(ValidationError, match=message):
+        load_agent_plugin(tmp_path)
+
+
+def test_ignores_unknown_manifest_fields_with_warning(tmp_path: Path) -> None:
+    """Unknown core fields are reported but do not reject the plugin."""
+    _write_manifest(tmp_path, typo=True)
+    _write_skill(tmp_path, "review")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.skills == ["review"]
+    assert plugin.warnings == ["plugin.json: ignoring unknown field 'typo'"]
+
+
+def test_rejects_extension_path_outside_plugin(tmp_path: Path) -> None:
+    """Extension paths cannot escape the plugin root through symlinks."""
+    outside = tmp_path.parent / "outside-commands"
+    outside.mkdir()
+    (outside / "bad.md").write_text("# Bad")
+    (tmp_path / "escape").symlink_to(outside, target_is_directory=True)
+    _write_manifest(
+        tmp_path,
+        extensions={
+            "dev.getlola": {"commands": "./escape"},
+        },
+    )
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.commands == []
+    assert "outside plugin root" in plugin.warnings[0]
+
+
+def test_skips_invalid_mcp_entries_independently(tmp_path: Path) -> None:
+    """One bad MCP server does not suppress independent valid servers."""
+    _write_manifest(tmp_path)
+    (tmp_path / "mcp.json").write_text(
+        json.dumps(
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "good": {"type": "stdio", "command": "uvx"},
+                    "bad": {"type": "stdio", "command": "uvx extra"},
+                },
+            }
+        )
+    )
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.mcps == ["good"]
+    assert "bad" in plugin.warnings[0]
+
+
+def test_skips_nonconforming_skill_independently(tmp_path: Path) -> None:
+    """Invalid skills are skipped without rejecting the plugin."""
+    _write_manifest(tmp_path)
+    _write_skill(tmp_path, "good")
+    bad = tmp_path / "skills" / "bad"
+    bad.mkdir()
+    (bad / "SKILL.md").write_text("# Missing frontmatter")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.skills == ["good"]
+    assert "skills/bad/SKILL.md" in plugin.warnings[0]
+
+
+def test_materializes_portable_mcp_values(tmp_path: Path) -> None:
+    """Portable types, paths, and placeholders become target-neutral data."""
+    root = tmp_path / "plugin"
+    data = tmp_path / "data"
+    root.mkdir()
+    servers = {
+        "local": {
+            "type": "stdio",
+            "command": "./bin/server",
+            "args": ["${PLUGIN_ROOT}/config.json"],
+            "env": {"CACHE": "${PLUGIN_DATA}/cache"},
+            "cwd": "./work",
+        },
+        "remote": {
+            "type": "streamable-http",
+            "url": "https://example.com/mcp",
+        },
+    }
+
+    result = materialize_mcps(servers, root, data)
+
+    assert "type" not in result["local"]
+    assert result["local"]["command"] == str(root / "bin/server")
+    assert result["local"]["args"] == [str(root.resolve() / "config.json")]
+    assert result["local"]["env"] == {
+        "CACHE": str(data.resolve() / "cache"),
+        "PLUGIN_ROOT": str(root.resolve()),
+        "PLUGIN_DATA": str(data.resolve()),
+    }
+    assert result["local"]["cwd"] == str(root / "work")
+    assert result["remote"]["type"] == "http"
+
+
+def test_manifest_metadata_validation_and_non_object_extensions(
+    tmp_path: Path,
+) -> None:
+    """Validate typed metadata while treating extensions as non-fatal."""
+    _write_manifest(
+        tmp_path,
+        author={"name": 1},
+        keywords="not-a-list",
+    )
+
+    with pytest.raises(ValidationError) as error:
+        load_agent_plugin(tmp_path)
+
+    assert "invalid author" in str(error.value)
+    assert "keywords must be an array" in str(error.value)
+
+    _write_manifest(tmp_path, extensions="invalid")
+    plugin = load_agent_plugin(tmp_path)
+    assert plugin.warnings == ["plugin.json: ignoring non-object extensions"]
+
+
+def test_ignores_unimplemented_extension_value(tmp_path: Path) -> None:
+    """Unknown namespace values are opaque even when not objects."""
+    _write_manifest(tmp_path, extensions={"org.example.client": "opaque"})
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.warnings == []
+
+
+def test_extension_path_validation_and_conventional_directory(
+    tmp_path: Path,
+) -> None:
+    """Read conventional extension directories and report invalid paths."""
+    _write_manifest(
+        tmp_path,
+        extensions={
+            "dev.getlola": {
+                "commands": "commands",
+                "instructions": 42,
+            }
+        },
+    )
+    commands = tmp_path / "dev.getlola" / "commands"
+    commands.mkdir(parents=True)
+    (commands / "check.md").write_text("# Check")
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.commands == []
+    assert len(plugin.warnings) == 2
+    assert "expected a './'" in plugin.warnings[0]
+
+
+@pytest.mark.parametrize(
+    ("mcp", "warning"),
+    [
+        ({"mcpServers": {}}, "unsupported or missing $schema"),
+        (
+            {"$schema": MCP_SCHEMA, "mcpServers": {}, "extra": True},
+            "invalid top-level fields",
+        ),
+        ({"$schema": MCP_SCHEMA, "mcpServers": []}, "must be an object"),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "stdio",
+                        "command": "uvx",
+                        "env": {"PLUGIN_ROOT": "bad"},
+                    }
+                },
+            },
+            "reserved variable",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "streamable-http",
+                        "url": "file:///bad",
+                    }
+                },
+            },
+            "http or https",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "sse",
+                        "url": "https://example.com",
+                        "headers": {"Authorization": "${TOKEN}"},
+                    }
+                },
+            },
+            "cannot contain placeholders",
+        ),
+    ],
+)
+def test_invalid_mcp_shapes_are_component_failures(
+    tmp_path: Path,
+    mcp: dict[str, object],
+    warning: str,
+) -> None:
+    """Malformed MCP documents and entries are reported and skipped."""
+    _write_manifest(tmp_path)
+    (tmp_path / "mcp.json").write_text(json.dumps(mcp))
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.mcps == []
+    assert warning in plugin.warnings[0]
+
+
+def test_materializes_default_stdio_environment(tmp_path: Path) -> None:
+    """Stdio servers receive required runtime variables and default cwd."""
+    root = tmp_path / "plugin"
+    data = tmp_path / "data"
+    root.mkdir()
+
+    result = materialize_mcps(
+        {"local": {"type": "stdio", "command": "uvx"}},
+        root,
+        data,
+    )
+
+    assert result["local"]["cwd"] == str(root.resolve())
+    assert result["local"]["env"] == {
+        "PLUGIN_ROOT": str(root.resolve()),
+        "PLUGIN_DATA": str(data.resolve()),
+    }
+
+
+def test_scaffold_minimal_and_invalid_name(tmp_path: Path) -> None:
+    """Minimal scaffolds stay conformant and reject invalid names."""
+    options = ScaffoldOptions(
+        skill_name=None,
+        command_name=None,
+        agent_name=None,
+        include_mcps=False,
+        include_instructions=False,
+    )
+
+    scaffold_agent_plugin(tmp_path / "valid", "valid.plugin", options)
+
+    assert (tmp_path / "valid" / "plugin.json").exists()
+    assert not (tmp_path / "valid" / "mcp.json").exists()
+    with pytest.raises(ValidationError, match="invalid Agent Plugins name"):
+        scaffold_agent_plugin(tmp_path / "bad", "Bad_Name", options)
+
+
+def test_scaffold_is_rerunnable(tmp_path: Path) -> None:
+    """Re-scaffolding an existing package refreshes files, not crash."""
+    options = ScaffoldOptions(
+        skill_name="example-skill",
+        command_name="example-command",
+        agent_name="example-agent",
+        include_mcps=True,
+        include_instructions=True,
+    )
+
+    scaffold_agent_plugin(tmp_path, "portable-plugin", options)
+    scaffold_agent_plugin(tmp_path, "portable-plugin", options)
+
+    assert (tmp_path / "skills" / "example-skill" / "SKILL.md").exists()
+
+
+def _register_plugin(modules_dir: Path) -> Path:
+    """Register a plugin with MCP servers in the mock registry."""
+    root = modules_dir / "portable-plugin"
+    root.mkdir()
+    _write_manifest(root)
+    _write_skill(root, "review")
+    (root / "mcp.json").write_text(
+        json.dumps(
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "local": {
+                        "type": "stdio",
+                        "command": "uvx",
+                        "args": ["serve", "${PLUGIN_ROOT}/rules.json"],
+                    },
+                    "remote": {
+                        "type": "streamable-http",
+                        "url": "https://example.com/mcp",
+                    },
+                },
+            }
+        )
+    )
+    return root
+
+
+def test_install_materializes_plugin_mcps(
+    tmp_path: Path, mock_lola_home: dict, cli_runner
+) -> None:
+    """Install writes target MCP config with expanded plugin paths."""
+    _register_plugin(mock_lola_home["modules"])
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = cli_runner.invoke(
+        install_cmd,
+        ["portable-plugin", str(project), "-a", "claude-code", "-f"],
+    )
+
+    assert result.exit_code == 0, result.output
+    servers = json.loads((project / ".mcp.json").read_text())["mcpServers"]
+    local_copy = (project / ".lola" / "modules" / "portable-plugin").resolve()
+    assert servers["local"]["args"] == [
+        "serve",
+        str(local_copy / "rules.json"),
+    ]
+    assert servers["local"]["env"]["PLUGIN_ROOT"] == str(local_copy)
+    assert servers["local"]["cwd"] == str(local_copy)
+    assert servers["remote"] == {
+        "type": "http",
+        "url": "https://example.com/mcp",
+    }
+    assert (project / ".lola" / "plugin-data" / "portable-plugin").is_dir()
+
+
+def test_update_rematerializes_plugin_mcps(
+    tmp_path: Path, mock_lola_home: dict, cli_runner
+) -> None:
+    """Update regenerates target MCP config from the plugin source."""
+    root = _register_plugin(mock_lola_home["modules"])
+    project = tmp_path / "project"
+    project.mkdir()
+    result = cli_runner.invoke(
+        install_cmd,
+        ["portable-plugin", str(project), "-a", "claude-code", "-f"],
+    )
+    assert result.exit_code == 0, result.output
+
+    mcp = json.loads((root / "mcp.json").read_text())
+    mcp["mcpServers"]["extra"] = {
+        "type": "sse",
+        "url": "https://example.com/sse",
+    }
+    (root / "mcp.json").write_text(json.dumps(mcp))
+
+    result = cli_runner.invoke(update_cmd, ["portable-plugin"])
+
+    assert result.exit_code == 0, result.output
+    servers = json.loads((project / ".mcp.json").read_text())["mcpServers"]
+    assert servers["extra"] == {
+        "type": "sse",
+        "url": "https://example.com/sse",
+    }
+    local_copy = (project / ".lola" / "modules" / "portable-plugin").resolve()
+    assert servers["local"]["env"]["PLUGIN_ROOT"] == str(local_copy)
+
+
+def test_command_expands_plugin_root_placeholder(tmp_path: Path) -> None:
+    """${PLUGIN_ROOT} is expanded in command, not just in args."""
+    servers = materialize_mcps(
+        {"s": {"type": "stdio", "command": "${PLUGIN_ROOT}/bin/serve"}},
+        tmp_path / "root",
+        tmp_path / "data",
+    )
+    assert servers["s"]["command"] == str((tmp_path / "root").resolve()) + (
+        "/bin/serve"
+    )
+
+
+def test_empty_plugin_is_not_a_module(tmp_path: Path) -> None:
+    """A manifest with no installable content yields no module."""
+    root = tmp_path / "empty"
+    root.mkdir()
+    _write_manifest(root)
+    assert Module.from_path(root) is None
+
+
+@pytest.mark.parametrize(
+    ("dirname", "expected"),
+    [
+        ("My_Project", "my-project"),
+        ("my-plugin", "my-plugin"),
+        ("_weird__name_", "weird-name"),
+    ],
+)
+def test_plugin_name_from_directory(dirname: str, expected: str) -> None:
+    """Inferred names are slugified rather than rejected."""
+    from lola.agent_plugin_scaffold import plugin_name_from_directory
+
+    assert plugin_name_from_directory(dirname) == expected
+
+
+def test_folder_source_finds_plugin_root_without_skills(tmp_path: Path) -> None:
+    """A commands-only plugin registers as the package root, not dev.getlola."""
+    from lola.parsers import FolderSourceHandler
+
+    source = tmp_path / "repository-name"
+    (source / "dev.getlola" / "commands").mkdir(parents=True)
+    _write_manifest(source, name="cmdonly")
+    (source / "dev.getlola" / "commands" / "foo.md").write_text(
+        "---\ndescription: x\n---\n"
+    )
+
+    dest = tmp_path / "modules"
+    dest.mkdir()
+    fetched = FolderSourceHandler().fetch(str(source), dest)
+
+    assert (fetched / "plugin.json").is_file()

--- a/tests/test_agent_plugins.py
+++ b/tests/test_agent_plugins.py
@@ -58,6 +58,42 @@ def test_loads_portable_core_and_manifest_name(tmp_path: Path) -> None:
     assert plugin.mcps == ["reviewer"]
 
 
+def test_module_loads_plugin_from_content_dirname(tmp_path: Path) -> None:
+    """A plugin selected by content_dirname uses the plugin adapter."""
+    nested = tmp_path / "packages" / "plugin"
+    nested.mkdir(parents=True)
+    _write_manifest(nested)
+    _write_skill(nested, "review")
+
+    module = Module.from_path(tmp_path, content_dirname="packages/plugin")
+
+    assert module is not None
+    assert module.name == "portable-plugin"
+    assert module.content_path == nested
+
+
+def test_loopback_http_mcp_url_is_allowed(tmp_path: Path) -> None:
+    """Plain HTTP is portable only for loopback hosts."""
+    _write_manifest(tmp_path)
+    (tmp_path / "mcp.json").write_text(
+        json.dumps(
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "local": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8080/mcp",
+                    }
+                },
+            }
+        )
+    )
+
+    plugin = load_agent_plugin(tmp_path)
+
+    assert plugin.mcps == ["local"]
+
+
 def test_module_reads_lola_namespace(tmp_path: Path) -> None:
     """Lola extensions provide non-portable commands and agents."""
     _write_manifest(
@@ -356,6 +392,69 @@ def test_extension_path_validation_and_conventional_directory(
                 },
             },
             "cannot contain placeholders",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {"type": "stdio", "command": "/tmp/server"},
+                },
+            },
+            "bare name or a ./ plugin path",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {"type": "stdio", "command": "bin/server"},
+                },
+            },
+            "bare name or a ./ plugin path",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "streamable-http",
+                        "url": "http://example.com/mcp",
+                    }
+                },
+            },
+            "https for non-loopback hosts",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "sse",
+                        "url": "https://user:pw@example.com/mcp",
+                    }
+                },
+            },
+            "userinfo or a fragment",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {
+                        "type": "sse",
+                        "url": "https://example.com/mcp#frag",
+                    }
+                },
+            },
+            "userinfo or a fragment",
+        ),
+        (
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "bad": {"type": "sse", "url": "https:///mcp"},
+                },
+            },
+            "absolute http or https URL",
         ),
     ],
 )

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -1,10 +1,26 @@
 """Tests for the mod CLI commands."""
 
+import json
 import shutil
 from unittest.mock import patch
 
 
+from lola.agent_plugins import PLUGIN_SCHEMA
 from lola.cli.mod import mod, list_registered_modules
+
+
+def _plugin_source(tmp_path, dirname, name):
+    """Create an Agent Plugins source folder with one skill."""
+    source = tmp_path / dirname
+    skill = source / "skills" / "review"
+    skill.mkdir(parents=True)
+    (source / "plugin.json").write_text(
+        json.dumps({"$schema": PLUGIN_SCHEMA, "name": name})
+    )
+    (skill / "SKILL.md").write_text(
+        "---\nname: review\ndescription: Review code\n---\n"
+    )
+    return source
 
 
 class TestModGroup:
@@ -21,6 +37,76 @@ class TestModGroup:
         result = cli_runner.invoke(mod, [])
         # Click groups with no args show usage/help
         assert "Manage lola modules" in result.output or "Usage" in result.output
+
+
+class TestAgentPluginInit:
+    """Tests for Agent Plugins scaffolding."""
+
+    def test_init_defaults_to_agent_plugins(self, cli_runner, tmp_path, monkeypatch):
+        """Bare init creates the portable core and Lola extension namespace."""
+        monkeypatch.chdir(tmp_path)
+
+        result = cli_runner.invoke(mod, ["init", "my-plugin"])
+
+        assert result.exit_code == 0
+        root = tmp_path / "my-plugin"
+        manifest = json.loads((root / "plugin.json").read_text())
+        mcps = json.loads((root / "mcp.json").read_text())
+        assert manifest["name"] == "my-plugin"
+        assert "dev.getlola" in manifest["extensions"]
+        assert mcps["$schema"].endswith("/1.0.0/mcp.schema.json")
+        assert (root / "skills" / "example-skill" / "SKILL.md").exists()
+        assert (root / "dev.getlola" / "commands" / "example-command.md").exists()
+        assert (root / "dev.getlola" / "agents" / "example-agent.md").exists()
+        assert (root / "dev.getlola" / "AGENTS.md").exists()
+        assert not (root / "module").exists()
+
+    def test_init_agent_plugin_existing_dir_needs_force(
+        self, cli_runner, tmp_path, monkeypatch
+    ):
+        """An existing directory errors unless --force is given."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "my-plugin").mkdir()
+
+        result = cli_runner.invoke(
+            mod, ["init", "my-plugin", "--format", "agent-plugins"]
+        )
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+
+        result = cli_runner.invoke(
+            mod,
+            ["init", "my-plugin", "--format", "agent-plugins", "--force"],
+        )
+        assert result.exit_code == 0
+        assert (tmp_path / "my-plugin" / "plugin.json").exists()
+
+    def test_init_agent_plugin_rerun_in_cwd(self, cli_runner, tmp_path, monkeypatch):
+        """Re-running init inside the package directory succeeds."""
+        plugin_dir = tmp_path / "my-plugin"
+        plugin_dir.mkdir()
+        monkeypatch.chdir(plugin_dir)
+
+        first = cli_runner.invoke(mod, ["init", "--format", "agent-plugins"])
+        second = cli_runner.invoke(mod, ["init", "--format", "agent-plugins"])
+
+        assert first.exit_code == 0
+        assert second.exit_code == 0
+        assert (plugin_dir / "plugin.json").exists()
+
+    def test_init_agent_plugin_rejects_invalid_name(
+        self, cli_runner, tmp_path, monkeypatch
+    ):
+        """Plugin scaffolds enforce the v1 manifest name constraints."""
+        monkeypatch.chdir(tmp_path)
+
+        result = cli_runner.invoke(
+            mod,
+            ["init", "Bad_Name", "--format", "agent-plugins"],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid Agent Plugins name" in result.output
 
 
 class TestModAdd:
@@ -47,6 +133,95 @@ class TestModAdd:
         assert result.exit_code == 0
         assert "Added" in result.output
         assert (modules_dir / "sample-module").exists()
+
+    def test_add_agent_plugin_uses_manifest_name(self, cli_runner, tmp_path):
+        """Register Agent Plugins by plugin.json.name, not source dirname."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(source)])
+
+        assert result.exit_code == 0
+        assert "Added manifest-name" in result.output
+        assert (modules_dir / "manifest-name").exists()
+        assert not (modules_dir / "repository-name").exists()
+
+    def test_add_agent_plugin_rejects_name_override(self, cli_runner, tmp_path):
+        """Do not override the identity declared by plugin.json.name."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(
+                mod,
+                ["add", str(source), "--name", "override"],
+            )
+
+        assert result.exit_code == 1
+        assert "plugin.json.name" in result.output
+
+    def test_add_agent_plugin_conflict_declined(self, cli_runner, tmp_path):
+        """Declining the manifest-name conflict keeps the existing module."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        existing = modules_dir / "manifest-name"
+        existing.mkdir(parents=True)
+        (existing / "keep.txt").write_text("original")
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(source)], input="n\n")
+
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+        assert (existing / "keep.txt").exists()
+        assert not (modules_dir / "repository-name").exists()
+
+    def test_add_agent_plugin_conflict_overwrites(self, cli_runner, tmp_path):
+        """Accepting the manifest-name conflict replaces the module."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        existing = modules_dir / "manifest-name"
+        existing.mkdir(parents=True)
+        (existing / "keep.txt").write_text("original")
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(source)], input="y\n")
+
+        assert result.exit_code == 0
+        assert "Added manifest-name" in result.output
+        assert (modules_dir / "manifest-name" / "plugin.json").exists()
+        assert not (existing / "keep.txt").exists()
+
+    def test_add_agent_plugin_invalid_manifest_errors(self, cli_runner, tmp_path):
+        """A broken plugin.json fails cleanly instead of crashing."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+        (source / "plugin.json").write_text(json.dumps({"name": "manifest-name"}))
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(source)])
+
+        assert result.exit_code == 1
+        assert "$schema" in result.output
 
     def test_add_with_name_override(self, cli_runner, sample_module, tmp_path):
         """Add module with custom name."""
@@ -219,6 +394,25 @@ class TestModList:
         assert result.exit_code == 0
         assert "sample-module" in result.output
 
+    def test_ls_skips_broken_plugin(self, cli_runner, sample_module, tmp_path):
+        """A registered module with a broken manifest is skipped, not fatal."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+        broken = modules_dir / "broken-plugin"
+        broken.mkdir()
+        (broken / "plugin.json").write_text("{not json")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["ls"])
+
+        assert result.exit_code == 0
+        assert "sample-module" in result.output
+        assert "broken-plugin" not in result.output
+
 
 class TestModRemove:
     """Tests for mod rm command."""
@@ -365,7 +559,7 @@ class TestModInit:
         """Show init help."""
         result = cli_runner.invoke(mod, ["init", "--help"])
         assert result.exit_code == 0
-        assert "Initialize a new lola module" in result.output
+        assert "Initialize a new module" in result.output
 
     def test_init_current_dir(self, cli_runner, tmp_path):
         """Initialize module in current directory."""
@@ -375,7 +569,7 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init"])
+            result = cli_runner.invoke(mod, ["init", "--format", "lola"])
 
             assert result.exit_code == 0
             assert "Initialized module" in result.output
@@ -396,7 +590,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "my-new-module"])
+            result = cli_runner.invoke(
+                mod, ["init", "my-new-module", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             assert "my-new-module" in result.output
@@ -430,7 +626,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod", "--no-skill"])
+            result = cli_runner.invoke(
+                mod, ["init", "mymod", "--no-skill", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             # Module directory should exist
@@ -458,7 +656,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod", "-s", "custom-skill"])
+            result = cli_runner.invoke(
+                mod, ["init", "mymod", "-s", "custom-skill", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             assert (
@@ -475,7 +675,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod", "-c", "my-cmd"])
+            result = cli_runner.invoke(
+                mod, ["init", "mymod", "-c", "my-cmd", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             assert (tmp_path / "mymod" / "module" / "commands" / "my-cmd.md").exists()
@@ -491,7 +693,7 @@ class TestModInit:
         try:
             os.chdir(tmp_path)
             (tmp_path / "existing").mkdir()
-            result = cli_runner.invoke(mod, ["init", "existing"])
+            result = cli_runner.invoke(mod, ["init", "existing", "--format", "lola"])
 
             assert result.exit_code == 1
             assert "already exists" in result.output
@@ -510,7 +712,7 @@ class TestModInit:
             (tmp_path / "module").mkdir()
             (tmp_path / "module" / "skills").mkdir()
             (tmp_path / "module" / "skills" / "example-skill").mkdir()
-            result = cli_runner.invoke(mod, ["init"])
+            result = cli_runner.invoke(mod, ["init", "--format", "lola"])
 
             # Command should succeed but warn about skipping existing skill
             assert result.exit_code == 0
@@ -528,7 +730,7 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod"])
+            result = cli_runner.invoke(mod, ["init", "mymod", "--format", "lola"])
 
             assert result.exit_code == 0
             mcps_file = tmp_path / "mymod" / "module" / MCPS_FILE
@@ -549,7 +751,7 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod"])
+            result = cli_runner.invoke(mod, ["init", "mymod", "--format", "lola"])
 
             assert result.exit_code == 0
             agents_file = tmp_path / "mymod" / "module" / "AGENTS.md"
@@ -572,7 +774,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod", "--no-mcps"])
+            result = cli_runner.invoke(
+                mod, ["init", "mymod", "--no-mcps", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             mcps_file = tmp_path / "mymod" / "module" / MCPS_FILE
@@ -588,7 +792,9 @@ class TestModInit:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "mymod", "--no-instructions"])
+            result = cli_runner.invoke(
+                mod, ["init", "mymod", "--no-instructions", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             agents_file = tmp_path / "mymod" / "module" / "AGENTS.md"
@@ -607,7 +813,8 @@ class TestModInit:
         try:
             os.chdir(tmp_path)
             result = cli_runner.invoke(
-                mod, ["init", "mymod", "--no-mcps", "--no-instructions"]
+                mod,
+                ["init", "mymod", "--no-mcps", "--no-instructions", "--format", "lola"],
             )
 
             assert result.exit_code == 0
@@ -635,6 +842,8 @@ class TestModInit:
                 [
                     "init",
                     "mymod",
+                    "--format",
+                    "lola",
                     "--no-skill",
                     "--no-command",
                     "--no-agent",
@@ -666,7 +875,18 @@ class TestModInit:
             os.chdir(tmp_path)
             result = cli_runner.invoke(
                 mod,
-                ["init", "mymod", "-s", "my-skill", "-c", "my-cmd", "-g", "my-agent"],
+                [
+                    "init",
+                    "mymod",
+                    "-s",
+                    "my-skill",
+                    "-c",
+                    "my-cmd",
+                    "-g",
+                    "my-agent",
+                    "--format",
+                    "lola",
+                ],
             )
 
             assert result.exit_code == 0
@@ -1097,7 +1317,7 @@ class TestModInitModuleSubdir:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "my-module"])
+            result = cli_runner.invoke(mod, ["init", "my-module", "--format", "lola"])
 
             assert result.exit_code == 0
             assert "Initialized module" in result.output
@@ -1130,7 +1350,7 @@ class TestModInitModuleSubdir:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "my-module"])
+            result = cli_runner.invoke(mod, ["init", "my-module", "--format", "lola"])
 
             assert result.exit_code == 0
             # README.md at repo root
@@ -1152,7 +1372,7 @@ class TestModInitModuleSubdir:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "my-module"])
+            result = cli_runner.invoke(mod, ["init", "my-module", "--format", "lola"])
 
             assert result.exit_code == 0
             # Check README.md has markers
@@ -1203,7 +1423,7 @@ class TestModInitModuleSubdir:
 
         try:
             os.chdir(named_dir)
-            result = cli_runner.invoke(mod, ["init"])
+            result = cli_runner.invoke(mod, ["init", "--format", "lola"])
 
             assert result.exit_code == 0
             assert "my-project" in result.output
@@ -1227,7 +1447,18 @@ class TestModInitModuleSubdir:
             os.chdir(tmp_path)
             result = cli_runner.invoke(
                 mod,
-                ["init", "my-mod", "-s", "my-skill", "-c", "my-cmd", "-g", "my-agent"],
+                [
+                    "init",
+                    "my-mod",
+                    "-s",
+                    "my-skill",
+                    "-c",
+                    "my-cmd",
+                    "-g",
+                    "my-agent",
+                    "--format",
+                    "lola",
+                ],
             )
 
             assert result.exit_code == 0
@@ -1246,7 +1477,9 @@ class TestModInitModuleSubdir:
 
         try:
             os.chdir(tmp_path)
-            result = cli_runner.invoke(mod, ["init", "my-module", "--minimal"])
+            result = cli_runner.invoke(
+                mod, ["init", "my-module", "--minimal", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             # Empty directories exist
@@ -1284,7 +1517,9 @@ class TestModInitModuleSubdir:
             existing.mkdir()
             (existing / "old-file.txt").write_text("old content")
 
-            result = cli_runner.invoke(mod, ["init", "my-module", "--force"])
+            result = cli_runner.invoke(
+                mod, ["init", "my-module", "--force", "--format", "lola"]
+            )
 
             assert result.exit_code == 0
             # New structure created
@@ -1306,7 +1541,7 @@ class TestModInitModuleSubdir:
             # Create existing directory
             (tmp_path / "existing").mkdir()
 
-            result = cli_runner.invoke(mod, ["init", "existing"])
+            result = cli_runner.invoke(mod, ["init", "existing", "--format", "lola"])
 
             assert result.exit_code == 1
             assert "already exists" in result.output

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -180,6 +180,7 @@ class TestModAdd:
         with (
             patch("lola.cli.mod.MODULES_DIR", modules_dir),
             patch("lola.cli.mod.ensure_lola_dirs"),
+            patch("lola.cli.mod.is_interactive", return_value=True),
         ):
             result = cli_runner.invoke(mod, ["add", str(source)], input="n\n")
 
@@ -199,6 +200,7 @@ class TestModAdd:
         with (
             patch("lola.cli.mod.MODULES_DIR", modules_dir),
             patch("lola.cli.mod.ensure_lola_dirs"),
+            patch("lola.cli.mod.is_interactive", return_value=True),
         ):
             result = cli_runner.invoke(mod, ["add", str(source)], input="y\n")
 
@@ -222,6 +224,27 @@ class TestModAdd:
 
         assert result.exit_code == 1
         assert "$schema" in result.output
+        assert not (modules_dir / "repository-name").exists()
+
+    def test_add_agent_plugin_conflict_non_interactive(self, cli_runner, tmp_path):
+        """The overwrite prompt is not reachable without a TTY."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        existing = modules_dir / "manifest-name"
+        existing.mkdir(parents=True)
+        (existing / "keep.txt").write_text("original")
+        source = _plugin_source(tmp_path, "repository-name", "manifest-name")
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+            patch("lola.cli.mod.is_interactive", return_value=False),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(source)])
+
+        assert result.exit_code == 1
+        assert "non-interactive" in result.output
+        assert (existing / "keep.txt").exists()
+        assert not (modules_dir / "repository-name").exists()
 
     def test_add_with_name_override(self, cli_runner, sample_module, tmp_path):
         """Add module with custom name."""
@@ -581,6 +604,61 @@ class TestModInit:
             assert (tmp_path / "module" / "agents" / "example-agent.md").exists()
         finally:
             os.chdir(original_dir)
+
+    def test_init_rejects_traversal_name(self, cli_runner, tmp_path):
+        """A name is a directory component, never a path to delete."""
+        import os
+
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keep.txt").write_text("original")
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        original_dir = os.getcwd()
+
+        try:
+            os.chdir(workdir)
+            result = cli_runner.invoke(mod, ["init", "../victim", "--force"])
+        finally:
+            os.chdir(original_dir)
+
+        assert result.exit_code == 1
+        assert (victim / "keep.txt").read_text() == "original"
+
+    def test_init_plugin_preserves_existing_files(self, cli_runner, tmp_path):
+        """Re-running init never overwrites an edited package."""
+        import os
+
+        (tmp_path / "plugin.json").write_text('{"name": "edited"}')
+        original_dir = os.getcwd()
+
+        try:
+            os.chdir(tmp_path)
+            result = cli_runner.invoke(mod, ["init"])
+        finally:
+            os.chdir(original_dir)
+
+        assert result.exit_code == 0
+        assert "already exists, skipping" in result.output
+        assert (tmp_path / "plugin.json").read_text() == '{"name": "edited"}'
+        assert (tmp_path / "README.md").exists()
+
+    def test_init_unslugifiable_directory_name(self, cli_runner, tmp_path):
+        """An underivable plugin name asks for an explicit one."""
+        import os
+
+        workdir = tmp_path / "___"
+        workdir.mkdir()
+        original_dir = os.getcwd()
+
+        try:
+            os.chdir(workdir)
+            result = cli_runner.invoke(mod, ["init"])
+        finally:
+            os.chdir(original_dir)
+
+        assert result.exit_code == 1
+        assert "pass a name" in result.output
 
     def test_init_with_name(self, cli_runner, tmp_path):
         """Initialize module with name creates subdirectory."""


### PR DESCRIPTION
## Summary

- Add first-class support for Agent Plugins 1.0 packages: `plugin.json` detection, spec-conformant validation, and adaptation into Lola's existing `Module` install/update contract, with the manifest `name` as module identity
- Materialize portable MCP config at install/update time (server types, `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` placeholders in command/args/env/cwd, per-module plugin-data directories) and read commands/agents/instructions from client extension namespaces (`dev.getlola` is Lola's own)
- Root zip/tar/folder sources at the shallowest `plugin.json` so namespace-only packages register correctly, and make agent-plugins the default format for `lola mod init` (inferred directory names are slugified; `--format lola` keeps the legacy `module/` layout)

## Related Issues

Fixes #232

## Spec / ADR Reference

ADR: docs/adr/agent-plugins-format.md

## Test Plan

- [x] `pytest` — 1139 tests pass, including new unit tests for plugin loading/validation, MCP materialization, source-root discovery, name slugification, registration conflicts, and end-to-end install/update of plugin MCPs
- [x] `make e2e` — 43 BDD scenarios pass, including new scenarios for default agent-plugins init, legacy `--format lola` init, and registering a plugin by its manifest name
- [x] `ruff check src tests`, `uv run ty check`, `uv run mypy src`, and pre-commit hooks (ruff-format, bandit) all clean

## Checklist

- [x] Tests pass (`pytest` / `go test -race ./...`)
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`)
- [ ] `go vet ./...` passes (Go changes only, N/A otherwise)
- [x] Type checking passes (`uv run ty check`)
- [x] Coverage >80% on changed source files (N/A for docs/config) — note: `targets/install.py` sits at ~60% overall from pre-existing untested code; the lines changed by this PR are covered
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

## AI Disclosure

AI-assisted with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mod init` now creates Agent Plugins packages by default, with optional skills, commands, agents, MCP configuration, and instructions.
  * Added `--format lola` for creating legacy Lola modules.
  * Agent Plugin packages are discovered, validated, registered, and installed using their declared names.
  * Added support for MCP configuration, instructions, and client extensions from Agent Plugin packages.

* **Documentation**
  * Updated CLI reference and module creation guides with Agent Plugins structure and legacy format instructions.

* **Changes**
  * Removed plugin-specific install, update, and uninstall options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->