### PR TITLE
docs(adr): extension sandboxing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ docs/superpowers/
 
 ### SDD — optional contributor tooling (not committed) ###
 .opencode/
+.test-output/

--- a/docs/adr/0007-extension-sandboxing.md
+++ b/docs/adr/0007-extension-sandboxing.md
@@ -1,0 +1,255 @@
+# ADR-0007: Extension Sandboxing
+
+**Status**: Proposed
+**Date**: 2026-08-25
+**Last Updated**: 2026-08-26
+**Authors**: trevor-vaughan
+**Reviewers**:
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+## Context
+
+[ADR-0003: Extension Architecture](extension-architecture.md) establishes that
+any developer can add targets, sources, and catalogs without forking Lola. That
+is the goal. It also means Lola will execute third-party code on developer
+workstations and in CI, during `lola install`.
+
+That code runs as an ordinary subprocess owned by the invoking user, under both
+the accepted design and the proposed one. ADR-0003 specifies that external
+extensions run as separate processes and gives the reason as "protecting core
+stability". The provider architecture proposed in #221 runs them through
+`hashicorp/go-plugin`, which describes its own isolation as:
+
+> Plugins can be relatively secure: The plugin only has access to the interfaces
+> and args given to it, **not to the entire memory space of the process**.
+
+That is memory isolation between host and plugin: it prevents a plugin crash
+from taking down the host. It is not privilege isolation. A subprocess extension
+can read `~/.ssh`, write `~/.bashrc`, and open outbound network connections,
+because it runs as the user. The provider architecture design compounds this by
+specifying provider-owned filesystem writes.
+
+Shipped code has the same shape. Issue #42 records that pre- and post-install
+hooks execute automatically, with the user's permissions and without a consent
+prompt, and asks for a warning and a confirmation before each one. A prompt is
+worth having. It also asks the person least able to answer it, at the moment
+they want the install to finish, about a script they have not read. Bounding
+what the script can reach is the part a prompt cannot do.
+
+The proposed sigstore integration ADR supplies *provenance* — who published this
+artifact. *Confinement* — what the artifact may do once running — is a separate
+axis. ADR-0006 covers the first; this ADR proposes the second.
+
+Extension authors must be able to use **Python, JavaScript, Go, and Rust**.
+
+## Decision
+
+Confinement comes from two layers, in priority order.
+
+### 1. Effects are host-mediated (primary guarantee)
+
+Extensions do not write files or open sockets. An extension receives input and
+returns a **plan**, a declarative description of the effects it wants. The host
+validates the plan against the extension's granted capabilities and performs the
+effects itself.
+
+This puts path validation, dry-run, atomic rollback, conflict detection, and
+audit logging in one place in the host, where they are written once and apply to
+every extension in every language and every tier.
+
+### 2. Execution is tiered
+
+| Tier               | Mechanism                                                                     | Languages             | Trust                                        |
+|--------------------|-------------------------------------------------------------------------------|-----------------------|----------------------------------------------|
+| **1 — WASM**       | `.wasm` module, WASI preview 1, run by wazero inside a self-exec shim process | Go, Rust, JavaScript  | Default. Capability-confined by the runtime. |
+| **2 — Subprocess** | Ordinary process speaking the same plan protocol over a pipe                  | Any, including Python | Opt-in per extension, signature required.    |
+
+Tier 1 is the default and the documented path. Tier 2 exists because Python
+cannot be compiled to WASI preview 1 without shipping a CPython interpreter, and
+Python is a required language. A tier-2 extension is still bound by the
+host-mediated interface: it receives input on stdin and returns a plan on
+stdout, and is granted no filesystem or network capability. Its additional risk
+is that nothing *enforces* that at the OS level.
+
+Installing a tier-2 extension requires an explicit opt-in and a valid signature.
+Lola reports the tier of every installed extension in `lola ext ls`.
+
+### 3. The shim is a self-exec
+
+The host re-executes its own binary as a hidden `lola __extension-host`
+subcommand. The child applies OS-level confinement, instantiates the WASM module
+through wazero with only the granted capabilities, and communicates with the
+parent over a pipe.
+
+Self-exec rather than a separate runner binary keeps Lola a single static
+artifact, which is the primary rationale of [ADR-0002: Go
+Migration](go-migration.md). Process isolation and capability isolation stack: a
+wazero bug does not immediately become host compromise, and the child can be
+resource-limited by the OS.
+
+On Linux the child also applies Landlock. This is defense in depth, not the
+guarantee — Landlock is unavailable on macOS and Windows, and the design must be
+safe without it.
+
+### 4. Capabilities are declared and granted, never assumed
+
+An extension declares required capabilities in its manifest. The host grants the
+narrowest set that satisfies the declaration, and denies by default. A target
+extension that declares no capabilities (the expected case, since it returns a
+write plan) runs with none.
+
+Credentials are held by the host and never handed to an extension. Issue #175
+asks for authenticated HTTP cloning of private repositories. Under a plan, the
+extension emits a `clone` intent naming the remote, and the host attaches
+whatever credential it holds for that remote. A source extension therefore never
+sees a token, which removes the question of whether it can be trusted with one.
+
+## Rationale
+
+- **The interface carries more weight than the sandbox.** A pure extension that
+  describes its effects is safe in any tier. An effectful extension needs a
+  perfect sandbox forever. Choosing the second is picking the harder problem.
+- **wazero is the only viable embedded runtime.** It is pure Go with no cgo,
+  which preserves the single static binary and one-step cross-compilation that
+  motivated the Go migration. `wasmtime-go` requires cgo and supports only
+  Linux/macOS/Windows on x86_64 — no Apple Silicon.
+- **Confinement and provenance are complementary.** Signing tells you who wrote
+  an extension; sandboxing bounds what it can do when the signer is wrong or
+  compromised.
+- **`lola install` runs in CI.** CI holds credentials and runs unattended, so an
+  unconfined extension has both the most to reach and the least chance of being
+  noticed.
+
+## Consequences
+
+### Positive Consequences
+
+- A malicious tier-1 extension cannot read `~/.ssh` or reach the network,
+  regardless of what its code attempts
+- Path validation, dry-run, and rollback are implemented once in the host rather
+  than correctly-or-otherwise in every extension
+- `.wasm` modules are single content-addressable artifacts, which fits the
+  `lola.sum` hashing proposed in the module package format ADR, and sigstore
+  bundle signing, directly
+- Dry-run (`--dry-run`) becomes trivial: execute the extension, print the plan,
+  do not apply
+- Extension crashes and infinite loops are contained by the shim process
+
+### Negative Consequences
+
+- Extension authors must target WASI preview 1 rather than writing a native
+  binary, which is a real ergonomic cost relative to a drop-in script
+- Python extensions get weaker enforcement than the other three languages — an
+  asymmetry that must be documented honestly rather than glossed
+- The plan protocol must express every effect an extension needs; an effect the
+  protocol cannot describe forces an extension into tier 2
+- Templating has to be placed deliberately. Issue #195 asks for inline
+  templating, and template expansion is evaluation, so the protocol must say
+  whether it happens inside the extension or in the host. If a plan can carry an
+  unexpanded template, then expanded output reaching a path field is
+  attacker-influenced input, and host-side path validation has to run after
+  expansion rather than before it
+- Two execution paths mean two code paths in the host and two sets of
+  integration tests
+- WASI preview 1 has no standard interface-type story, so the ABI is Lola's to
+  define and version
+- The self-exec shim adds process-spawn latency to every extension invocation
+
+## Alternatives Considered
+
+### Alternative 1: Unsandboxed subprocess only
+- Description: extensions are ordinary binaries; security rests on signing. This
+  is the status quo of both the extension architecture and provider architecture
+  proposals.
+- Pros: any language including shell; simplest possible authoring; no ABI to
+  define
+- Cons: no confinement whatsoever; a compromised signing identity or a malicious
+  extension in a marketplace has full user privileges, including in CI
+- Reason for rejection: provenance without confinement is a single point of
+  failure. This remains available as tier 2 for cases that need it, with opt-in
+  and signing.
+
+### Alternative 2: WebAssembly Component Model (WASI 0.2)
+- Description: target WASI 0.2 with WIT interfaces; first-class Python via
+  `componentize-py` and JavaScript via ComponentizeJS
+- Pros: typed interfaces with generated bindings; Python is first-class rather
+  than an exception; the direction the ecosystem is moving
+- Cons: no pure-Go runtime implements it. Reaching it requires `wasmtime-go`
+  (cgo, x86_64-only) or shipping a second non-Go runner binary, forfeiting the
+  single-binary property
+- Reason for rejection: deferred, not rejected on merit. Revisit when a pure-Go
+  component-model runtime exists; the plan protocol should not obstruct that
+  migration.
+
+### Alternative 3: Extism
+- Description: an established plugin framework built on wazero, with PDKs for
+  several languages
+- Pros: solves memory management and host functions; proven pattern; avoids
+  defining an ABI
+- Cons: no Python PDK, which fails a stated requirement. Separately,
+  `extism/go-sdk` — the exact component Lola would depend on — was last updated
+  2025-05-14
+- Reason for rejection: fails the language requirement, with a maintenance
+  concern on the specific dependency as a second reason
+
+### Alternative 4: OCI containers per extension
+- Description: each extension is a container image, executed by a container
+  runtime
+- Pros: strong isolation; any language; familiar packaging
+- Cons: requires a container runtime on every user's machine and in CI; startup
+  cost; poor fit for a tool whose selling point is a single static binary
+- Reason for rejection: contradicts the distribution model established by the Go
+  migration
+
+### Alternative 5: Subprocess plus OS sandboxing only
+- Description: keep native binaries, confine with Landlock, `sandbox-exec`, and
+  AppContainer
+- Pros: any language including shell, with real confinement on Linux
+- Cons: three separate platform implementations with materially different
+  guarantees; the macOS and Windows stories are substantially weaker; nothing is
+  portable
+- Reason for rejection: the guarantee would vary by platform, which is the
+  hardest kind of security property to document or reason about. Retained as a
+  hardening layer on Linux.
+
+## Implementation Notes
+
+- Prerequisites: [ADR-0002: Go Migration](go-migration.md), [ADR-0003: Extension
+  Architecture](extension-architecture.md)
+- Paired design: [Extension Sandboxing
+  design](../dev-guide/design/extension-sandboxing.md)
+- New dependencies, vetted and approved:
+  - `github.com/tetratelabs/wazero` v1.12.0 — Apache-2.0, zero transitive
+    dependencies, 81 contributors, last release 2026-05-29
+  - `github.com/landlock-lsm/go-landlock` v0.10.0 — MIT, Linux-only hardening.
+    Single-maintainer risk accepted: the API surface is small, the layer is
+    strictly additive, and abandonment means dropping the layer rather than a
+    rewrite.
+- This ADR constrains but does not decide the extension transport. It is
+  compatible with either the stdin/stdout protocol or a gRPC provider model,
+  because the plan protocol is a payload shape rather than a transport.
+  Whichever transport is chosen must carry plans rather than granting effects.
+- ADR-0004 (Go Project Structure, in review as #111) gains an
+  `internal/extensions/host/` package for the shim. `pkg/sdk/` gains the plan
+  types, which are part of the public contract.
+
+## References
+
+- [ADR-0003: Extension Architecture](extension-architecture.md)
+- [ADR-0002: Go Migration](go-migration.md)
+- ADR-0004: Go Project Structure, in review as #111
+- [wazero specifications](https://wazero.io/specs/) — Core 1.0/2.0 and
+  `wasi_snapshot_preview1`
+- [wasmtime-go README](https://github.com/bytecodealliance/wasmtime-go) — cgo
+  and x86_64-only support statement
+- [hashicorp/go-plugin
+  architecture](https://github.com/hashicorp/go-plugin#architecture) —
+  "relatively secure" isolation claim
+- [Landlock LSM](https://landlock.io/)
+- Issue #42 — install hooks execute without a consent prompt
+- Issue #175 — authenticated HTTP cloning for private repositories
+- Issue #195 — inline templating

--- a/docs/adr/extension-sandboxing.md
+++ b/docs/adr/extension-sandboxing.md
@@ -1,0 +1,256 @@
+# ADR: Extension Sandboxing
+
+**Status**: Proposed
+**Date**: 2026-08-25
+**Last Updated**: 2026-08-26
+**Authors**: trevor-vaughan
+**Reviewers**:
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+## Context
+
+[ADR: Extension Architecture](extension-architecture.md) establishes that
+any developer can add targets, sources, and catalogs without forking Lola. That
+is the goal. It also means Lola will execute third-party code on developer
+workstations and in CI, during `lola install`.
+
+That code runs as an ordinary subprocess owned by the invoking user, under both
+the accepted design and the proposed one. The extension architecture ADR
+specifies that external extensions run as separate processes and gives the
+reason as "protecting core stability". The provider architecture proposed in
+#221 runs them through `hashicorp/go-plugin`, which describes its own isolation
+as:
+
+> Plugins can be relatively secure: The plugin only has access to the interfaces
+> and args given to it, **not to the entire memory space of the process**.
+
+That is memory isolation between host and plugin: it prevents a plugin crash
+from taking down the host. It is not privilege isolation. A subprocess extension
+can read `~/.ssh`, write `~/.bashrc`, and open outbound network connections,
+because it runs as the user. The provider architecture design compounds this by
+specifying provider-owned filesystem writes.
+
+Shipped code has the same shape. Issue #42 records that pre- and post-install
+hooks execute automatically, with the user's permissions and without a consent
+prompt, and asks for a warning and a confirmation before each one. A prompt is
+worth having. It also asks the person least able to answer it, at the moment
+they want the install to finish, about a script they have not read. Bounding
+what the script can reach is the part a prompt cannot do.
+
+The proposed sigstore integration ADR supplies *provenance* — who published this
+artifact. *Confinement* — what the artifact may do once running — is a separate
+axis. That ADR covers the first; this ADR proposes the second.
+
+Extension authors must be able to use **Python, JavaScript, Go, and Rust**.
+
+## Decision
+
+Confinement comes from two layers, in priority order.
+
+### 1. Effects are host-mediated (primary guarantee)
+
+Extensions do not write files or open sockets. An extension receives input and
+returns a **plan**, a declarative description of the effects it wants. The host
+validates the plan against the extension's granted capabilities and performs the
+effects itself.
+
+This puts path validation, dry-run, atomic rollback, conflict detection, and
+audit logging in one place in the host, where they are written once and apply to
+every extension in every language and every tier.
+
+### 2. Execution is tiered
+
+| Tier               | Mechanism                                                                     | Languages             | Trust                                        |
+|--------------------|-------------------------------------------------------------------------------|-----------------------|----------------------------------------------|
+| **1 — WASM**       | `.wasm` module, WASI preview 1, run by wazero inside a self-exec shim process | Go, Rust, JavaScript  | Default. Capability-confined by the runtime. |
+| **2 — Subprocess** | Ordinary process speaking the same plan protocol over a pipe                  | Any, including Python | Opt-in per extension, signature required.    |
+
+Tier 1 is the default and the documented path. Tier 2 exists because Python
+cannot be compiled to WASI preview 1 without shipping a CPython interpreter, and
+Python is a required language. A tier-2 extension is still bound by the
+host-mediated interface: it receives input on stdin and returns a plan on
+stdout, and is granted no filesystem or network capability. Its additional risk
+is that nothing *enforces* that at the OS level.
+
+Installing a tier-2 extension requires an explicit opt-in and a valid signature.
+Lola reports the tier of every installed extension in `lola ext ls`.
+
+### 3. The shim is a self-exec
+
+The host re-executes its own binary as a hidden `lola __extension-host`
+subcommand. The child applies OS-level confinement, instantiates the WASM module
+through wazero with only the granted capabilities, and communicates with the
+parent over a pipe.
+
+Self-exec rather than a separate runner binary keeps Lola a single static
+artifact, which is the primary rationale of [ADR: Go
+Migration](go-migration.md). Process isolation and capability isolation stack: a
+wazero bug does not immediately become host compromise, and the child can be
+resource-limited by the OS.
+
+On Linux the child also applies Landlock. This is defense in depth, not the
+guarantee — Landlock is unavailable on macOS and Windows, and the design must be
+safe without it.
+
+### 4. Capabilities are declared and granted, never assumed
+
+An extension declares required capabilities in its manifest. The host grants the
+narrowest set that satisfies the declaration, and denies by default. A target
+extension that declares no capabilities (the expected case, since it returns a
+write plan) runs with none.
+
+Credentials are held by the host and never handed to an extension. Issue #175
+asks for authenticated HTTP cloning of private repositories. Under a plan, the
+extension emits a `clone` intent naming the remote, and the host attaches
+whatever credential it holds for that remote. A source extension therefore never
+sees a token, which removes the question of whether it can be trusted with one.
+
+## Rationale
+
+- **The interface carries more weight than the sandbox.** A pure extension that
+  describes its effects is safe in any tier. An effectful extension needs a
+  perfect sandbox forever. Choosing the second is picking the harder problem.
+- **wazero is the only viable embedded runtime.** It is pure Go with no cgo,
+  which preserves the single static binary and one-step cross-compilation that
+  motivated the Go migration. `wasmtime-go` requires cgo and supports only
+  Linux/macOS/Windows on x86_64 — no Apple Silicon.
+- **Confinement and provenance are complementary.** Signing tells you who wrote
+  an extension; sandboxing bounds what it can do when the signer is wrong or
+  compromised.
+- **`lola install` runs in CI.** CI holds credentials and runs unattended, so an
+  unconfined extension has both the most to reach and the least chance of being
+  noticed.
+
+## Consequences
+
+### Positive Consequences
+
+- A malicious tier-1 extension cannot read `~/.ssh` or reach the network,
+  regardless of what its code attempts
+- Path validation, dry-run, and rollback are implemented once in the host rather
+  than correctly-or-otherwise in every extension
+- `.wasm` modules are single content-addressable artifacts, which fits the
+  `lola.sum` hashing proposed in the module package format ADR, and sigstore
+  bundle signing, directly
+- Dry-run (`--dry-run`) becomes trivial: execute the extension, print the plan,
+  do not apply
+- Extension crashes and infinite loops are contained by the shim process
+
+### Negative Consequences
+
+- Extension authors must target WASI preview 1 rather than writing a native
+  binary, which is a real ergonomic cost relative to a drop-in script
+- Python extensions get weaker enforcement than the other three languages — an
+  asymmetry that must be documented honestly rather than glossed
+- The plan protocol must express every effect an extension needs; an effect the
+  protocol cannot describe forces an extension into tier 2
+- Templating has to be placed deliberately. Issue #195 asks for inline
+  templating, and template expansion is evaluation, so the protocol must say
+  whether it happens inside the extension or in the host. If a plan can carry an
+  unexpanded template, then expanded output reaching a path field is
+  attacker-influenced input, and host-side path validation has to run after
+  expansion rather than before it
+- Two execution paths mean two code paths in the host and two sets of
+  integration tests
+- WASI preview 1 has no standard interface-type story, so the ABI is Lola's to
+  define and version
+- The self-exec shim adds process-spawn latency to every extension invocation
+
+## Alternatives Considered
+
+### Alternative 1: Unsandboxed subprocess only
+- Description: extensions are ordinary binaries; security rests on signing. This
+  is the status quo of both the extension architecture and provider architecture
+  proposals.
+- Pros: any language including shell; simplest possible authoring; no ABI to
+  define
+- Cons: no confinement whatsoever; a compromised signing identity or a malicious
+  extension in a marketplace has full user privileges, including in CI
+- Reason for rejection: provenance without confinement is a single point of
+  failure. This remains available as tier 2 for cases that need it, with opt-in
+  and signing.
+
+### Alternative 2: WebAssembly Component Model (WASI 0.2)
+- Description: target WASI 0.2 with WIT interfaces; first-class Python via
+  `componentize-py` and JavaScript via ComponentizeJS
+- Pros: typed interfaces with generated bindings; Python is first-class rather
+  than an exception; the direction the ecosystem is moving
+- Cons: no pure-Go runtime implements it. Reaching it requires `wasmtime-go`
+  (cgo, x86_64-only) or shipping a second non-Go runner binary, forfeiting the
+  single-binary property
+- Reason for rejection: deferred, not rejected on merit. Revisit when a pure-Go
+  component-model runtime exists; the plan protocol should not obstruct that
+  migration.
+
+### Alternative 3: Extism
+- Description: an established plugin framework built on wazero, with PDKs for
+  several languages
+- Pros: solves memory management and host functions; proven pattern; avoids
+  defining an ABI
+- Cons: no Python PDK, which fails a stated requirement. Separately,
+  `extism/go-sdk` — the exact component Lola would depend on — was last updated
+  2025-05-14
+- Reason for rejection: fails the language requirement, with a maintenance
+  concern on the specific dependency as a second reason
+
+### Alternative 4: OCI containers per extension
+- Description: each extension is a container image, executed by a container
+  runtime
+- Pros: strong isolation; any language; familiar packaging
+- Cons: requires a container runtime on every user's machine and in CI; startup
+  cost; poor fit for a tool whose selling point is a single static binary
+- Reason for rejection: contradicts the distribution model established by the Go
+  migration
+
+### Alternative 5: Subprocess plus OS sandboxing only
+- Description: keep native binaries, confine with Landlock, `sandbox-exec`, and
+  AppContainer
+- Pros: any language including shell, with real confinement on Linux
+- Cons: three separate platform implementations with materially different
+  guarantees; the macOS and Windows stories are substantially weaker; nothing is
+  portable
+- Reason for rejection: the guarantee would vary by platform, which is the
+  hardest kind of security property to document or reason about. Retained as a
+  hardening layer on Linux.
+
+## Implementation Notes
+
+- Prerequisites: [ADR: Go Migration](go-migration.md), [ADR: Extension
+  Architecture](extension-architecture.md)
+- Paired design: [Extension Sandboxing
+  design](../dev-guide/design/extension-sandboxing.md)
+- New dependencies, vetted and approved:
+  - `github.com/tetratelabs/wazero` v1.12.0 — Apache-2.0, zero transitive
+    dependencies, 81 contributors, last release 2026-05-29
+  - `github.com/landlock-lsm/go-landlock` v0.10.0 — MIT, Linux-only hardening.
+    Single-maintainer risk accepted: the API surface is small, the layer is
+    strictly additive, and abandonment means dropping the layer rather than a
+    rewrite.
+- This ADR constrains but does not decide the extension transport. It is
+  compatible with either the stdin/stdout protocol or a gRPC provider model,
+  because the plan protocol is a payload shape rather than a transport.
+  Whichever transport is chosen must carry plans rather than granting effects.
+- The Go project structure ADR (in review as #111) gains an
+  `internal/extensions/host/` package for the shim. `pkg/sdk/` gains the plan
+  types, which are part of the public contract.
+
+## References
+
+- [ADR: Extension Architecture](extension-architecture.md)
+- [ADR: Go Migration](go-migration.md)
+- ADR: Go Project Structure, in review as #111
+- [wazero specifications](https://wazero.io/specs/) — Core 1.0/2.0 and
+  `wasi_snapshot_preview1`
+- [wasmtime-go README](https://github.com/bytecodealliance/wasmtime-go) — cgo
+  and x86_64-only support statement
+- [hashicorp/go-plugin
+  architecture](https://github.com/hashicorp/go-plugin#architecture) —
+  "relatively secure" isolation claim
+- [Landlock LSM](https://landlock.io/)
+- Issue #42 — install hooks execute without a consent prompt
+- Issue #175 — authenticated HTTP cloning for private repositories
+- Issue #195 — inline templating

--- a/docs/adr/extension-sandboxing.md
+++ b/docs/adr/extension-sandboxing.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-08-25
-**Last Updated**: 2026-08-26
+**Last Updated**: 2026-09-09
 **Authors**: trevor-vaughan
 **Reviewers**:
 
@@ -22,8 +22,8 @@ That code runs as an ordinary subprocess owned by the invoking user, under both
 the accepted design and the proposed one. The extension architecture ADR
 specifies that external extensions run as separate processes and gives the
 reason as "protecting core stability". The provider architecture proposed in
-#221 runs them through `hashicorp/go-plugin`, which describes its own isolation
-as:
+issue #221 runs them through `hashicorp/go-plugin`, which describes its own
+isolation as:
 
 > Plugins can be relatively secure: The plugin only has access to the interfaces
 > and args given to it, **not to the entire memory space of the process**.
@@ -56,11 +56,15 @@ Confinement comes from two layers, in priority order.
 Extensions do not write files or open sockets. An extension receives input and
 returns a **plan**, a declarative description of the effects it wants. The host
 validates the plan against the extension's granted capabilities and performs the
-effects itself.
+effects itself. That is a statement about the interface every extension speaks;
+section 2 says where it is enforced and where it is only expected.
 
 This puts path validation, dry-run, atomic rollback, conflict detection, and
-audit logging in one place in the host, where they are written once and apply to
-every extension in every language and every tier.
+audit logging in one place in the host, where they are written once rather than
+per extension or per language. Path validation, rollback, conflict detection,
+and audit logging apply to every plan in both tiers. Dry-run applies in tier 1
+only: previewing a plan means running the extension that produced it, which is
+not a safe thing to do unconfined. See Positive Consequences.
 
 ### 2. Execution is tiered
 
@@ -71,10 +75,15 @@ every extension in every language and every tier.
 
 Tier 1 is the default and the documented path. Tier 2 exists because Python
 cannot be compiled to WASI preview 1 without shipping a CPython interpreter, and
-Python is a required language. A tier-2 extension is still bound by the
-host-mediated interface: it receives input on stdin and returns a plan on
-stdout, and is granted no filesystem or network capability. Its additional risk
-is that nothing *enforces* that at the OS level.
+Python is a required language. A tier-2 extension speaks the same
+host-mediated interface: it receives input on stdin, returns a plan on stdout,
+and declares the same capabilities, which the host executes for it exactly as
+it does for tier 1. The difference is that the interface is a contract rather
+than a boundary. Nothing at the OS level stops a tier-2 process reaching the
+filesystem or the network directly, so tier 2 is *trusted* to stay inside the
+contract where tier 1 is *confined* to it. That is what the opt-in and the
+signature are buying, and it is why an extension that does reach outside the
+contract cannot be promoted to tier 1 (see section 5 and the paired design).
 
 Installing a tier-2 extension requires an explicit opt-in and a valid signature.
 Lola reports the tier of every installed extension in `lola ext ls`.
@@ -83,8 +92,10 @@ Lola reports the tier of every installed extension in `lola ext ls`.
 
 The host re-executes its own binary as a hidden `lola __extension-host`
 subcommand. The child applies OS-level confinement, instantiates the WASM module
-through wazero with only the granted capabilities, and communicates with the
-parent over a pipe.
+through wazero with no ambient authority — no preopened directories, no
+environment, no argv — and communicates with the parent over a pipe. Every
+capability the protocol defines is executed by the host, so the child's
+confinement does not vary with what the extension was granted.
 
 Self-exec rather than a separate runner binary keeps Lola a single static
 artifact, which is the primary rationale of [ADR: Go
@@ -109,6 +120,34 @@ extension emits a `clone` intent naming the remote, and the host attaches
 whatever credential it holds for that remote. A source extension therefore never
 sees a token, which removes the question of whether it can be trusted with one.
 
+### 5. Existing install hooks convert or become tier 2
+
+The pre- and post-install hooks in [Install
+Hooks](../guides/install-hooks.md) are shell scripts that Lola runs with the
+user's permissions. They predate this ADR and are the concrete case behind
+issue #42.
+
+A hook is an extension like any other. A hook that copies files, writes
+configuration, or fetches a resource is expressible as a plan and converts to
+tier 1. A hook that must run an arbitrary command on the host is not
+expressible as a plan at all — there is no `exec` intent, by design — so it
+becomes a tier-2 extension and performs that command itself, outside the
+contract section 2 describes. Tier 2 is where that is possible rather than
+where it is sanctioned: explicit opt-in, valid signature, reported as
+`native`, and never promotable to tier 1. An arbitrary-command hook is
+carried, not blessed, and the honest description of it is a trusted native
+program that Lola launches and audits rather than confines.
+
+There is no third state, and the cutover is a single point rather than a
+gradual one. Deprecation runs entirely on today's code path: until the
+extension host ships, hooks execute as they do now and `lola install` warns on
+each one, naming the tier it would convert to. From the release that carries
+the extension host, `lola install` runs no script it has not loaded as an
+extension, so an unconverted hook is refused rather than silently executed.
+Nothing runs unconfined and unannounced in between. This ADR fixes that end
+state; which release carries it, and therefore how long authors have to
+convert, is decided when the extension host ships.
+
 ## Rationale
 
 - **The interface carries more weight than the sandbox.** A pure extension that
@@ -129,15 +168,21 @@ sees a token, which removes the question of whether it can be trusted with one.
 
 ### Positive Consequences
 
-- A malicious tier-1 extension cannot read `~/.ssh` or reach the network,
-  regardless of what its code attempts
+- A malicious tier-1 extension cannot read `~/.ssh`, and cannot reach the
+  network except through the `fetch` and `clone` intents its declared
+  capabilities allow, which the host executes and polices — regardless of what
+  its code attempts
 - Path validation, dry-run, and rollback are implemented once in the host rather
   than correctly-or-otherwise in every extension
 - `.wasm` modules are single content-addressable artifacts, which fits the
   `lola.sum` hashing proposed in the module package format ADR, and sigstore
   bundle signing, directly
-- Dry-run (`--dry-run`) becomes trivial: execute the extension, print the plan,
-  do not apply
+- Dry-run (`--dry-run`) becomes trivial for tier 1: execute the extension,
+  print the plan, do not apply. Nothing the module did can have escaped the
+  sandbox, so the preview is faithful. Tier 2 has no such property — running
+  the extension is itself the risk, because nothing prevents an unconfined
+  process acting before the host declines its plan. `--dry-run` therefore
+  refuses tier-2 extensions rather than offering a preview it cannot honour
 - Extension crashes and infinite loops are contained by the shim process
 
 ### Negative Consequences
@@ -146,8 +191,17 @@ sees a token, which removes the question of whether it can be trusted with one.
   binary, which is a real ergonomic cost relative to a drop-in script
 - Python extensions get weaker enforcement than the other three languages — an
   asymmetry that must be documented honestly rather than glossed
+- Install hooks stop working as written. Every hook converts to a
+  plan-returning extension or is re-declared as tier 2, which is a breaking
+  change for modules shipping hooks today
 - The plan protocol must express every effect an extension needs; an effect the
   protocol cannot describe forces an extension into tier 2
+- Two such effects are already known. There is no intent for replacing a
+  directory in one step, so an extension regenerating a subtree deletes and
+  rewrites it rather than swapping it atomically; and a plan cannot write
+  through a symlink, where the installer today removes the link and writes in
+  its place. Both are recorded in the paired design, and neither has a
+  tier-1 workaround
 - Templating has to be placed deliberately. Issue #195 asks for inline
   templating, and template expansion is evaluation, so the protocol must say
   whether it happens inside the extension or in the host. If a plan can carry an
@@ -224,12 +278,15 @@ sees a token, which removes the question of whether it can be trusted with one.
 - Paired design: [Extension Sandboxing
   design](../dev-guide/design/extension-sandboxing.md)
 - New dependencies, vetted and approved:
-  - `github.com/tetratelabs/wazero` v1.12.0 — Apache-2.0, zero transitive
-    dependencies, 81 contributors, last release 2026-05-29
-  - `github.com/landlock-lsm/go-landlock` v0.10.0 — MIT, Linux-only hardening.
-    Single-maintainer risk accepted: the API surface is small, the layer is
-    strictly additive, and abandonment means dropping the layer rather than a
-    rewrite.
+  - `github.com/tetratelabs/wazero` v1.12.0 — Apache-2.0, 81 contributors,
+    last release 2026-05-29. One dependency, `golang.org/x/sys` v0.44.0, used
+    for CPU feature detection, W^X memory mapping, and the platform syscall
+    layer beneath WASI
+  - `github.com/landlock-lsm/go-landlock` v0.10.0 — MIT, Linux-only
+    hardening. Depends on `golang.org/x/sys` and
+    `kernel.org/pub/linux/libs/security/libcap/psx`. Single-maintainer risk
+    accepted: the API surface is small, the layer is strictly additive, and
+    abandonment means dropping the layer rather than a rewrite.
 - This ADR constrains but does not decide the extension transport. It is
   compatible with either the stdin/stdout protocol or a gRPC provider model,
   because the plan protocol is a payload shape rather than a transport.

--- a/docs/dev-guide/design/extension-sandboxing.md
+++ b/docs/dev-guide/design/extension-sandboxing.md
@@ -1,0 +1,165 @@
+# Extension Sandboxing — Implementation Design
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+Paired with [ADR-0007: Extension
+Sandboxing](../../adr/0007-extension-sandboxing.md).
+
+## The plan protocol
+
+An extension never performs an effect. It receives a request and returns a
+**plan**: a declarative description of what it wants to happen. The host
+validates the plan and executes it.
+
+```mermaid
+graph LR
+    HOST["lola host"] -->|request| SHIM["shim process"]
+    SHIM -->|instantiate| WASM["wazero + .wasm"]
+    WASM -->|plan| SHIM
+    SHIM -->|plan| HOST
+    HOST -->|validated effects| FS["filesystem / network"]
+
+    style WASM fill:#90ee90,stroke:#333
+    style FS fill:#ffd7a0,stroke:#333
+```
+
+Green = untrusted extension code. Orange = the only component that touches the
+outside world, and it is host code.
+
+### Plan shape
+
+A plan is a list of intents. The host rejects any intent the extension lacks
+capability for, and rejects the whole plan rather than applying it partially.
+
+| Intent   | Fields                             | Used by                          |
+|----------|------------------------------------|----------------------------------|
+| `write`  | `path`, `mode`, `content`          | target extensions                |
+| `delete` | `path`                             | target uninstall                 |
+| `rename` | `from`, `to`                       | target migration between layouts |
+| `fetch`  | `url`, `method`, `headers`, `dest` | source extensions                |
+| `clone`  | `repo`, `ref`, `depth`, `dest`     | git source extensions            |
+
+`fetch` and `clone` are executed by the host's own HTTP and `go-git` clients.
+This is a security control and a feature: proxy configuration, credential
+handling, TLS policy, retry, and cache behaviour are implemented once in the
+host rather than reimplemented per source extension.
+
+### Path validation
+
+Every `path` in a plan is resolved against a root the host chose, then checked
+to be within it after symlink resolution. Absolute paths, `..` traversal, and
+symlinks escaping the root are rejected. Extensions never learn the absolute
+root; they receive root-relative paths and return root-relative paths.
+
+Plans are applied atomically: the host stages writes, verifies the complete
+plan, then commits. A failure mid-apply rolls back to the pre-plan state.
+
+## Capabilities
+
+An extension declares what it needs in its manifest. The host grants exactly
+that or refuses to load the extension. Absent declaration means no capability.
+
+```yaml
+capabilities:
+  - net.http          # host performs the fetch; extension supplies the intent
+  - net.git           # host performs the clone
+```
+
+| Capability | Grants                   | Notes                                               |
+|------------|--------------------------|-----------------------------------------------------|
+| *(none)*   | plan-only operation      | the expected case for target extensions             |
+| `net.http` | `fetch` intents accepted | host executes; extension never opens a socket       |
+| `net.git`  | `clone` intents accepted | host executes via `go-git`                          |
+| `net.raw`  | direct socket access     | **tier 2 only**; cannot be granted to a WASM module |
+
+There is no filesystem capability. Filesystem access is always mediated by the
+plan.
+
+## The shim
+
+The host re-executes its own binary as a hidden subcommand:
+
+```
+lola __extension-host --module <path> --caps <granted>
+```
+
+The subcommand is registered on the root command with `Hidden: true` so it does
+not appear in help or completion. The parent passes the request on the child's
+stdin and reads the plan from its stdout; stderr is captured and surfaced as
+extension diagnostics.
+
+The child, in order:
+
+1. Applies OS confinement. On Linux this is Landlock restricting the process to
+   no filesystem access at all, since the WASM module receives its input over
+   the pipe. On macOS and Windows this step is a no-op and the guarantee rests
+   on wazero.
+2. Instantiates the module with wazero, configured with no preopened
+   directories, no environment variables, and no argv beyond what the request
+   specifies.
+3. Enforces limits: wall-clock timeout, memory ceiling, and a fuel budget so a
+   module cannot spin forever.
+4. Writes the plan to stdout and exits.
+
+A child that exceeds any limit is killed and its plan discarded. Extension
+failure never leaves partial state, because nothing was applied.
+
+## Tiers
+
+|            | Tier 1                              | Tier 2                                    |
+|------------|-------------------------------------|-------------------------------------------|
+| Artifact   | `.wasm` module                      | native binary                             |
+| Runtime    | wazero, WASI preview 1              | OS process                                |
+| Filesystem | none — plan-mediated                | none granted, **not enforced**            |
+| Network    | `net.http` / `net.git` intents only | `net.raw` available                       |
+| Install    | default                             | explicit opt-in, valid signature required |
+| Listed as  | `wasm` in `lola ext ls`             | `native` in `lola ext ls`                 |
+
+Tier 2 speaks the identical plan protocol over the identical pipe. The
+difference is enforcement, not interface, which means an extension can be
+promoted from tier 2 to tier 1 by recompiling, with no code change.
+
+## Authoring toolchain
+
+| Language   | Target                    | Notes                                                         |
+|------------|---------------------------|---------------------------------------------------------------|
+| Go         | `GOOS=wasip1 GOARCH=wasm` | native since Go 1.21                                          |
+| Rust       | `wasm32-wasip1`           | `rustup target add wasm32-wasip1`                             |
+| JavaScript | `javy`                    | compiles JS to a WASI p1 module via QuickJS; small artifacts  |
+| Python     | **tier 2**                | CPython cannot target WASI p1 without shipping an interpreter |
+
+The Python asymmetry is documented in user-facing docs rather than hidden. A
+Python extension is a normal binary or script; it is signed, opt-in, and
+reported as `native`.
+
+## ABI
+
+WASI preview 1 has no interface-type mechanism, so the module contract is Lola's
+to define:
+
+- The module exports `lola_run() -> i32`, returning a status code.
+- The host writes the request into module memory before the call and reads the
+  plan out after it, using two exported helpers, `lola_alloc(size) -> ptr` and
+  `lola_plan_ptr() -> ptr`, following the pattern established by Extism.
+- Request and plan are JSON. The volume is small (a module list and a file
+  plan), so a binary encoding is not worth the tooling cost.
+- The ABI carries a version integer. The host refuses modules whose ABI version
+  it does not implement, with an error naming both versions.
+
+## Testing
+
+- **Plan validation** is unit-tested against hostile inputs directly: `..`
+  traversal, absolute paths, symlinks pointing outside the root, and paths that
+  only escape after the second resolution.
+- **Confinement** is tested with purpose-built hostile modules — one that
+  attempts to open `/etc/passwd`, one that attempts a socket, one that allocates
+  without bound, one that never returns. Each must fail in the expected way, and
+  each is a regression test.
+- **Tier parity** is tested by compiling the same fixture extension to both
+  tiers and asserting identical plans, which is what makes promotion a
+  recompile.
+- **Atomicity** is tested by injecting a failure partway through apply and
+  asserting the tree matches its pre-plan state.

--- a/docs/dev-guide/design/extension-sandboxing.md
+++ b/docs/dev-guide/design/extension-sandboxing.md
@@ -1,0 +1,164 @@
+# Extension Sandboxing — Implementation Design
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+Paired with [ADR: Extension Sandboxing](../../adr/extension-sandboxing.md).
+
+## The plan protocol
+
+An extension never performs an effect. It receives a request and returns a
+**plan**: a declarative description of what it wants to happen. The host
+validates the plan and executes it.
+
+```mermaid
+graph LR
+    HOST["lola host"] -->|request| SHIM["shim process"]
+    SHIM -->|instantiate| WASM["wazero + .wasm"]
+    WASM -->|plan| SHIM
+    SHIM -->|plan| HOST
+    HOST -->|validated effects| FS["filesystem / network"]
+
+    style WASM fill:#90ee90,stroke:#333
+    style FS fill:#ffd7a0,stroke:#333
+```
+
+Green = untrusted extension code. Orange = the only component that touches the
+outside world, and it is host code.
+
+### Plan shape
+
+A plan is a list of intents. The host rejects any intent the extension lacks
+capability for, and rejects the whole plan rather than applying it partially.
+
+| Intent   | Fields                             | Used by                          |
+|----------|------------------------------------|----------------------------------|
+| `write`  | `path`, `mode`, `content`          | target extensions                |
+| `delete` | `path`                             | target uninstall                 |
+| `rename` | `from`, `to`                       | target migration between layouts |
+| `fetch`  | `url`, `method`, `headers`, `dest` | source extensions                |
+| `clone`  | `repo`, `ref`, `depth`, `dest`     | git source extensions            |
+
+`fetch` and `clone` are executed by the host's own HTTP and `go-git` clients.
+This is a security control and a feature: proxy configuration, credential
+handling, TLS policy, retry, and cache behaviour are implemented once in the
+host rather than reimplemented per source extension.
+
+### Path validation
+
+Every `path` in a plan is resolved against a root the host chose, then checked
+to be within it after symlink resolution. Absolute paths, `..` traversal, and
+symlinks escaping the root are rejected. Extensions never learn the absolute
+root; they receive root-relative paths and return root-relative paths.
+
+Plans are applied atomically: the host stages writes, verifies the complete
+plan, then commits. A failure mid-apply rolls back to the pre-plan state.
+
+## Capabilities
+
+An extension declares what it needs in its manifest. The host grants exactly
+that or refuses to load the extension. Absent declaration means no capability.
+
+```yaml
+capabilities:
+  - net.http          # host performs the fetch; extension supplies the intent
+  - net.git           # host performs the clone
+```
+
+| Capability | Grants                   | Notes                                               |
+|------------|--------------------------|-----------------------------------------------------|
+| *(none)*   | plan-only operation      | the expected case for target extensions             |
+| `net.http` | `fetch` intents accepted | host executes; extension never opens a socket       |
+| `net.git`  | `clone` intents accepted | host executes via `go-git`                          |
+| `net.raw`  | direct socket access     | **tier 2 only**; cannot be granted to a WASM module |
+
+There is no filesystem capability. Filesystem access is always mediated by the
+plan.
+
+## The shim
+
+The host re-executes its own binary as a hidden subcommand:
+
+```
+lola __extension-host --module <path> --caps <granted>
+```
+
+The subcommand is registered on the root command with `Hidden: true` so it does
+not appear in help or completion. The parent passes the request on the child's
+stdin and reads the plan from its stdout; stderr is captured and surfaced as
+extension diagnostics.
+
+The child, in order:
+
+1. Applies OS confinement. On Linux this is Landlock restricting the process to
+   no filesystem access at all, since the WASM module receives its input over
+   the pipe. On macOS and Windows this step is a no-op and the guarantee rests
+   on wazero.
+2. Instantiates the module with wazero, configured with no preopened
+   directories, no environment variables, and no argv beyond what the request
+   specifies.
+3. Enforces limits: wall-clock timeout, memory ceiling, and a fuel budget so a
+   module cannot spin forever.
+4. Writes the plan to stdout and exits.
+
+A child that exceeds any limit is killed and its plan discarded. Extension
+failure never leaves partial state, because nothing was applied.
+
+## Tiers
+
+|            | Tier 1                              | Tier 2                                    |
+|------------|-------------------------------------|-------------------------------------------|
+| Artifact   | `.wasm` module                      | native binary                             |
+| Runtime    | wazero, WASI preview 1              | OS process                                |
+| Filesystem | none — plan-mediated                | none granted, **not enforced**            |
+| Network    | `net.http` / `net.git` intents only | `net.raw` available                       |
+| Install    | default                             | explicit opt-in, valid signature required |
+| Listed as  | `wasm` in `lola ext ls`             | `native` in `lola ext ls`                 |
+
+Tier 2 speaks the identical plan protocol over the identical pipe. The
+difference is enforcement, not interface, which means an extension can be
+promoted from tier 2 to tier 1 by recompiling, with no code change.
+
+## Authoring toolchain
+
+| Language   | Target                    | Notes                                                         |
+|------------|---------------------------|---------------------------------------------------------------|
+| Go         | `GOOS=wasip1 GOARCH=wasm` | native since Go 1.21                                          |
+| Rust       | `wasm32-wasip1`           | `rustup target add wasm32-wasip1`                             |
+| JavaScript | `javy`                    | compiles JS to a WASI p1 module via QuickJS; small artifacts  |
+| Python     | **tier 2**                | CPython cannot target WASI p1 without shipping an interpreter |
+
+The Python asymmetry is documented in user-facing docs rather than hidden. A
+Python extension is a normal binary or script; it is signed, opt-in, and
+reported as `native`.
+
+## ABI
+
+WASI preview 1 has no interface-type mechanism, so the module contract is Lola's
+to define:
+
+- The module exports `lola_run() -> i32`, returning a status code.
+- The host writes the request into module memory before the call and reads the
+  plan out after it, using two exported helpers, `lola_alloc(size) -> ptr` and
+  `lola_plan_ptr() -> ptr`, following the pattern established by Extism.
+- Request and plan are JSON. The volume is small (a module list and a file
+  plan), so a binary encoding is not worth the tooling cost.
+- The ABI carries a version integer. The host refuses modules whose ABI version
+  it does not implement, with an error naming both versions.
+
+## Testing
+
+- **Plan validation** is unit-tested against hostile inputs directly: `..`
+  traversal, absolute paths, symlinks pointing outside the root, and paths that
+  only escape after the second resolution.
+- **Confinement** is tested with purpose-built hostile modules — one that
+  attempts to open `/etc/passwd`, one that attempts a socket, one that allocates
+  without bound, one that never returns. Each must fail in the expected way, and
+  each is a regression test.
+- **Tier parity** is tested by compiling the same fixture extension to both
+  tiers and asserting identical plans, which is what makes promotion a
+  recompile.
+- **Atomicity** is tested by injecting a failure partway through apply and
+  asserting the tree matches its pre-plan state.

--- a/docs/dev-guide/design/extension-sandboxing.md
+++ b/docs/dev-guide/design/extension-sandboxing.md
@@ -33,33 +33,225 @@ outside world, and it is host code.
 A plan is a list of intents. The host rejects any intent the extension lacks
 capability for, and rejects the whole plan rather than applying it partially.
 
-| Intent   | Fields                             | Used by                          |
-|----------|------------------------------------|----------------------------------|
-| `write`  | `path`, `mode`, `content`          | target extensions                |
-| `delete` | `path`                             | target uninstall                 |
-| `rename` | `from`, `to`                       | target migration between layouts |
-| `fetch`  | `url`, `method`, `headers`, `dest` | source extensions                |
-| `clone`  | `repo`, `ref`, `depth`, `dest`     | git source extensions            |
+| Intent   | Fields                                            | Used by                          |
+|----------|---------------------------------------------------|----------------------------------|
+| `write`  | `path`, `mode`, `content`                         | target extensions                |
+| `delete` | `path`                                            | target uninstall                 |
+| `rename` | `from`, `to`                                      | target migration between layouts |
+| `fetch`  | `url`, `method` (`GET`/`HEAD`), `headers`, `dest` | source extensions                |
+| `clone`  | `repo`, `ref`, `depth`, `dest`                    | git source extensions            |
 
 `fetch` and `clone` are executed by the host's own HTTP and `go-git` clients.
 This is a security control and a feature: proxy configuration, credential
 handling, TLS policy, retry, and cache behaviour are implemented once in the
 host rather than reimplemented per source extension.
 
+### Remote access policy
+
+A `fetch` or `clone` intent names a destination; the host decides whether to
+reach it. The policy is host-side and identical in both tiers.
+
+- **Schemes.** `https` for `fetch`; `https` or `ssh` for `clone`. Plain
+  `http` is rejected rather than silently upgraded, so a downgrade is an
+  error the author sees while authoring.
+- **Methods.** `fetch` carries `GET` or `HEAD` and nothing else. The plan's
+  atomicity guarantee covers the local tree, and a remote mutation cannot be
+  rolled back when a later intent fails, nor made safe to retry. Restricting
+  the method keeps the guarantee honest rather than qualifying it. An
+  extension that needs to write to a remote is out of scope for this protocol
+  and stays so until a capability with explicit idempotency and retry rules
+  is designed for it.
+- **Destinations.** The host rejects loopback, link-local, and private-range
+  addresses. The check runs against the resolved address, not the hostname,
+  and runs again on every redirect hop. Whether an operator can re-admit a
+  specific destination, and at what scope, is host configuration this document
+  does not specify — the default is refusal, and nothing an extension declares
+  can change it.
+- **Request headers.** The `headers` an extension supplies are carried, except
+  that `Authorization`, `Cookie`, and `Proxy-Authorization` are dropped. An
+  extension cannot smuggle a credential outward by naming it as a header, and
+  cannot override the one the host attached.
+- **Address pinning.** The connection is dialled to the address that was
+  checked, not re-resolved from the name afterwards. Resolving, validating,
+  and then handing the URL to an HTTP client is the same check-then-use gap
+  described under path validation below: the client resolves again at dial
+  time and a name that answered publicly once can answer `127.0.0.1` the
+  second time. Pinning the dial to the checked address is what closes it, and
+  it applies per hop.
+- **Redirects.** Followed to a bounded depth, each hop validated and pinned as
+  above. Credentials are attached per hop rather than carried across hops: a
+  redirect that changes host drops every `Authorization` header and cookie
+  instead of replaying it.
+- **Credentials.** Supplied by the host from its own store, keyed to the
+  remote as the extension named it — scheme, host, and path — never to the
+  address that name resolved to, which is not stable behind a CDN or a
+  multi-address host. An extension names a remote, never a credential, and no
+  credential appears in the request the extension receives or the plan it
+  returns.
+- **Response exposure.** The extension does not see the response. `fetch`
+  writes to `dest` and `clone` writes a checkout; both are effects the host
+  performs after the extension has already returned its plan, and the protocol
+  has no second call in which a response could be handed back. An extension
+  that must branch on a status code or a header needs a request-side
+  capability that does not exist yet, and is out of scope here.
+- **Cache.** Keyed by extension identity as well as URL, so one extension
+  cannot read another's fetched bytes out of a shared cache.
+
+### Conflict rules
+
+A plan is a set, not a script: the host does not apply intents in the order
+the extension emitted them.
+
+An intent **touches** every path it names. For `write`, `delete`, `fetch`, and
+`clone` that is one path — `path` or `dest`. For `rename` it is two, `from`
+and `to`. Stating the rules over touched paths rather than destinations is
+what makes them complete: a `rename` reads one path and writes another, and
+both are paths another intent can invalidate.
+
+Two paths are the same path when the target filesystem says they are, not when
+their bytes match. The comparison folds case where the filesystem does and
+normalizes Unicode where it does, so `write README.md` alongside `delete
+Readme.md` is a conflict on macOS and Windows and two separate files on Linux.
+Comparing text instead would let a plan pass validation on the maintainer's
+machine and collide on a contributor's, which is the failure the whole section
+exists to prevent.
+
+Before staging, the host rejects the whole plan if either of the following
+holds for any two intents. Both tests compare paths component by component
+under the equality relation just described, so `Skills/Foo` is an ancestor of
+`skills/foo/SKILL.md` wherever the filesystem says it is.
+
+- They touch the same path. This covers a `write` and a `delete` on one path,
+  two `write`s, two `rename`s sharing a source, a `rename` into a path
+  something else writes, and — because a cycle of renames must repeat a path
+  pairwise — every rename cycle.
+- One's touched path lies beneath the other's. A plan holding `write a` and
+  `write a/b` is rejected rather than ordered, since one wants `a` to be a
+  file and the other wants it to be a directory. So is `rename a -> x`
+  alongside `rename a/b -> y`, where whichever rename ran first would decide
+  whether the second found anything to move.
+
+Both rules share one exception, and it is what makes the common cases
+expressible. A path that is, or lies beneath, the `path` named by a `delete`
+intent does not conflict with that delete, unless the path in question is a
+`rename` source. Deletes run before everything else, so the outcome is fixed
+however the intents were emitted: `delete skills/foo` alongside `write
+skills/foo/SKILL.md` drops a stale skill and regenerates it, and `delete
+vendor/x` alongside `clone dest=vendor/x` re-clones from scratch, which
+otherwise fails because `go-git` refuses to clone over an existing repository.
+`delete a` alongside `rename a/b -> c` stays rejected, because the delete
+would remove the path the rename reads.
+
+The exception is about the delete's own `path`, not everything underneath it.
+In `delete a` with `write a/b` and `write a/b/c`, the delete excuses each write
+against itself, and the two writes are still judged against each other by rule
+two — one wants `a/b` to be a file, the other a directory, so the plan is
+rejected.
+
+`delete` on a path that does not exist is a no-op rather than an error, which
+is what makes two nested deletes safe: `delete a` with `delete a/b` produces
+the same tree whichever runs first, since the survivor finds nothing to do.
+
+Rejection is whole-plan and names the conflicting intents. There is no partial
+apply and no last-writer-wins.
+
+Surviving plans are applied deletes first, then renames, then writes, with
+`fetch` and `clone` ordered as writes since they produce content at a
+destination. Any two surviving intents that share or nest a path do so only
+because a `delete` excused them, and deletes run first, so no intent can
+remove or change the type of a path a later phase depends on, and the same
+plan produces the same tree on every host regardless of emission order. The
+ordering between kinds is fixed so that a plan is reproducible; it is not
+resolving conflicts, because nothing that reaches it conflicts.
+
+Replacing a subtree in one step is still not expressible. `rename staged ->
+skills/foo` alongside `write skills/foo/SKILL.md` is rejected, and there is no
+intent meaning "replace this directory", so an extension that needs atomic
+subtree replacement rather than delete-then-write has no plan for it. That is
+a known gap, recorded as a negative consequence in the ADR.
+
 ### Path validation
 
-Every `path` in a plan is resolved against a root the host chose, then checked
-to be within it after symlink resolution. Absolute paths, `..` traversal, and
-symlinks escaping the root are rejected. Extensions never learn the absolute
-root; they receive root-relative paths and return root-relative paths.
+Every location a plan names is resolved against a root the host chose, then
+checked to be within it. That means `path` on `write` and `delete`, both ends
+of a `rename`, and `dest` on `fetch` and `clone` — an intent that reaches the
+filesystem is validated whatever the field is called. Absolute paths, `..`
+traversal, and any path traversing a symlink are rejected. Extensions never
+learn the absolute root; they receive root-relative paths and return
+root-relative paths.
 
-Plans are applied atomically: the host stages writes, verifies the complete
-plan, then commits. A failure mid-apply rolls back to the pre-plan state.
+Validation and commit share a file descriptor rather than a path. The host
+opens the root once and resolves every plan path relative to that descriptor —
+with `openat2` under `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` on Linux, and
+elsewhere by walking the path one component at a time and refusing any
+component that is a symlink. A path is therefore never re-resolved between the
+check and the write, which is what makes a concurrent symlink swap
+unexploitable rather than merely unlikely.
+
+Symlinks are not followed at all, on any platform. Following only the ones
+that stay beneath the root sounds narrower and is not expressible: under
+`openat2`, `RESOLVE_BENEATH` rejects every absolute symlink whatever its
+target, and `RESOLVE_IN_ROOT` reinterprets it relative to the root rather than
+following it, so a rule phrased around "stays beneath" would mean something
+different on Linux than in a component walk. Refusing all of them is the same
+rule everywhere.
+
+The installer Lola ships today agrees that a managed path must never be
+written *through* a symlink, and issue #226 is why. It differs in what it does
+next: `unlink_symlink_if_present` removes the link and writes a real file or
+directory in its place, so the install continues, while `_path_contains_symlink`
+defeats the idempotency shortcut so the user is asked first. A plan cannot do
+that. Path validation rejects the intent, and rejection is whole-plan, so one
+symlinked path fails the entire install rather than replacing the link and
+carrying on.
+
+Whether an extension should be able to express "replace this symlink", and
+whether the consent step that guards it today survives into the plan protocol,
+is left to the implementation issue. It is a real gap and not an oversight.
+
+Plans are applied atomically: the host stages the whole plan, verifies it,
+then commits. A failure mid-apply rolls back to the pre-plan state.
+
+Deletes are staged, not performed. A `delete` moves its target aside into a
+staging area and commit is what discards it, because rollback has to restore
+a subtree the host would otherwise no longer hold. That matters more since
+deletes may now be paired with writes beneath them: `delete skills/foo`
+followed by two writes into `skills/foo` is one plan, and if the second write
+fails, the first write is undone and the deleted subtree is moved back. A
+delete that ran destructively in its own phase would leave nothing to move
+back and the guarantee would be false for exactly the plans the conflict
+rules were relaxed to allow.
+
+Rollback is a recovery mechanism, not a containment one — it cannot undo a
+write that landed outside the root, which is why the descriptor discipline
+above carries the guarantee.
+
+### Audit log
+
+Every plan the host applies is logged before it is applied: the extension's
+identity and version, its tier, the capabilities it was granted, and every
+intent with its resolved paths. What the plan could not state in advance is
+appended as it happens — for `fetch` and `clone`, the address actually dialled
+at each redirect hop, which only exists once resolution and pinning have run.
+Rejections are logged with the rule that rejected them. Content bodies are not
+logged; their hashes are.
+
+The log is the only control tier 2 has that tier 1 does not get for free. A
+tier-1 module cannot act outside its plan, so its log is a convenience. A
+tier-2 extension is trusted rather than confined and may act before the host
+ever sees a plan, so the log is the record of what it declared it would do,
+against which its actual effect on the tree can be compared. That is what the
+ADR means by launching and auditing a native extension rather than confining
+it, and it is why the log covers both tiers rather than only the enforced one.
 
 ## Capabilities
 
-An extension declares what it needs in its manifest. The host grants exactly
-that or refuses to load the extension. Absent declaration means no capability.
+An extension declares what it needs in its manifest. The host grants the
+narrowest set that satisfies the declaration and denies anything undeclared.
+A declaration naming a capability the host does not define is refused at load
+rather than trimmed to the subset the host recognises, so an extension built
+against a newer capability set fails loudly instead of running with less
+authority than it expects. Absent declaration means no capability.
 
 ```yaml
 capabilities:
@@ -67,12 +259,11 @@ capabilities:
   - net.git           # host performs the clone
 ```
 
-| Capability | Grants                   | Notes                                               |
-|------------|--------------------------|-----------------------------------------------------|
-| *(none)*   | plan-only operation      | the expected case for target extensions             |
-| `net.http` | `fetch` intents accepted | host executes; extension never opens a socket       |
-| `net.git`  | `clone` intents accepted | host executes via `go-git`                          |
-| `net.raw`  | direct socket access     | **tier 2 only**; cannot be granted to a WASM module |
+| Capability | Grants                   | Notes                                         |
+|------------|--------------------------|-----------------------------------------------|
+| *(none)*   | plan-only operation      | the expected case for target extensions       |
+| `net.http` | `fetch` intents accepted | host executes; extension never opens a socket |
+| `net.git`  | `clone` intents accepted | host executes via `go-git`                    |
 
 There is no filesystem capability. Filesystem access is always mediated by the
 plan.
@@ -90,21 +281,53 @@ not appear in help or completion. The parent passes the request on the child's
 stdin and reads the plan from its stdout; stderr is captured and surfaced as
 extension diagnostics.
 
+`--caps` does not change what the child does. Both defined capabilities are
+host-executed and the child never interprets the plan it forwards, so its
+confinement is identical whatever it is granted; the flag is carried for the
+audit record and for the case that does not exist yet. If a capability is ever
+added that the module itself must exercise, this is what would carry it, and
+the child's confinement would stop being uniform. Until then the enforcement
+point for every capability is the host, and the steps below are the same for
+every extension.
+
 The child, in order:
 
-1. Applies OS confinement. On Linux this is Landlock restricting the process to
-   no filesystem access at all, since the WASM module receives its input over
-   the pipe. On macOS and Windows this step is a no-op and the guarantee rests
-   on wazero.
-2. Instantiates the module with wazero, configured with no preopened
-   directories, no environment variables, and no argv beyond what the request
-   specifies.
-3. Enforces limits: wall-clock timeout, memory ceiling, and a fuel budget so a
-   module cannot spin forever.
-4. Writes the plan to stdout and exits.
+1. Reads the module artifact into memory. This happens first because the
+   artifact is named by path on the command line, and the next step makes that
+   path unreachable.
+2. Applies OS confinement. On Linux this is Landlock restricting the process
+   to no filesystem access at all, which is possible precisely because the
+   module bytes are already in memory and the request arrives on an
+   already-open pipe. On macOS and Windows this step is a no-op and the
+   guarantee rests on wazero.
+3. Instantiates the module from those bytes with wazero, configured with no
+   preopened directories, no environment variables, and no argv. The request
+   reaches the module through the ABI call described below, not through its
+   process environment.
+4. Runs the module under a memory ceiling and a wall-clock timeout, the
+   timeout enforced by cancelling the module's context. Those two are the
+   whole runaway-execution budget: wazero exposes no instruction or fuel
+   metering, so a module that spins is stopped by the clock and by nothing
+   finer.
+5. Copies the plan out of module memory, refusing a plan whose declared
+   length exceeds the maximum plan size before copying anything, then writes
+   it to stdout and exits.
 
-A child that exceeds any limit is killed and its plan discarded. Extension
-failure never leaves partial state, because nothing was applied.
+A child that exceeds any limit is killed and its output discarded without
+being parsed. Extension failure never leaves partial state, because nothing
+was applied.
+
+The maximum plan size is enforced twice, at two different layers, because
+there are two ways to overrun it. The shim applies it in step 5 against the
+length the module declares, so an oversized plan is never copied out of linear
+memory in the first place. The host applies it again to whatever arrives on a
+child's stdout, through a bounded reader that caps total bytes, intent count,
+and the size of any single content field, and kills a child that exceeds any
+of them. The host's copy is the one that covers tier 2, which has no shim at
+all: a tier-2 extension is an ordinary process on the other end of the same
+pipe, and an unbounded native writer would otherwise exhaust host memory or
+block it. Neither layer is redundant — the shim bound protects the shim, and
+the host bound is the only one a tier-2 extension ever meets.
 
 ## Tiers
 
@@ -113,13 +336,16 @@ failure never leaves partial state, because nothing was applied.
 | Artifact   | `.wasm` module                      | native binary                             |
 | Runtime    | wazero, WASI preview 1              | OS process                                |
 | Filesystem | none — plan-mediated                | none granted, **not enforced**            |
-| Network    | `net.http` / `net.git` intents only | `net.raw` available                       |
+| Network    | `net.http` / `net.git` intents only | as tier 1; direct access **not enforced** |
 | Install    | default                             | explicit opt-in, valid signature required |
 | Listed as  | `wasm` in `lola ext ls`             | `native` in `lola ext ls`                 |
 
 Tier 2 speaks the identical plan protocol over the identical pipe. The
-difference is enforcement, not interface, which means an extension can be
-promoted from tier 2 to tier 1 by recompiling, with no code change.
+difference is enforcement, not interface. An extension that confines itself to
+the plan ABI is promoted from tier 2 to tier 1 by recompiling to a WASI
+preview 1 target, with no code change. An extension that reaches the
+filesystem or the network directly — which nothing in tier 2 stops it doing —
+is not promotable until those calls become intents.
 
 ## Authoring toolchain
 
@@ -139,20 +365,73 @@ reported as `native`.
 WASI preview 1 has no interface-type mechanism, so the module contract is Lola's
 to define:
 
-- The module exports `lola_run() -> i32`, returning a status code.
-- The host writes the request into module memory before the call and reads the
-  plan out after it, using two exported helpers, `lola_alloc(size) -> ptr` and
-  `lola_plan_ptr() -> ptr`, following the pattern established by Extism.
+Every call below is made by the shim child, which is the process that embeds
+wazero. The host never touches module memory; it sees only what the child
+writes to stdout.
+
+- The module exports `lola_run(req_ptr, req_len) -> i32`, returning a status
+  code. The child allocates the request buffer through the module's own
+  `lola_alloc(size) -> ptr`, copies the request bytes in, and passes that
+  pointer and length as the call's arguments, so the module is never left
+  guessing where its input is or how far it extends.
+- The child reads the plan back through `lola_plan_ptr() -> ptr` and
+  `lola_plan_len() -> i32`, following the pattern established by Extism. It
+  reads them only after `lola_run` returns success, and rejects any pair whose
+  extent falls outside the module's linear memory or exceeds the maximum plan
+  size. A length of zero is an empty plan, which is a distinct outcome from a
+  failure status.
+- Both buffers live in the module's linear memory and are owned by the module.
+  The request buffer stays valid for the duration of the call; the plan buffer
+  stays valid until the instance is discarded. The child copies the plan bytes
+  out and never writes to that region.
 - Request and plan are JSON. The volume is small (a module list and a file
   plan), so a binary encoding is not worth the tooling cost.
-- The ABI carries a version integer. The host refuses modules whose ABI version
-  it does not implement, with an error naming both versions.
+- The ABI carries a version integer, exported by the module. The child reads
+  it before calling `lola_run`, refuses a module whose version it does not
+  implement, and reports the mismatch to the host naming both versions.
 
 ## Testing
 
 - **Plan validation** is unit-tested against hostile inputs directly: `..`
-  traversal, absolute paths, symlinks pointing outside the root, and paths that
-  only escape after the second resolution.
+  traversal, absolute paths, symlinks pointing outside the root, symlinks
+  pointing inside it, and paths that only escape after the second resolution.
+- **Symlink policy** is tested on every platform and asserts the same outcome
+  on each: a plan path traversing a symlink is rejected whether the link
+  target is inside the root or outside it. Both cases are asserted precisely
+  because the rule is stricter than the installer's, and a platform that
+  quietly followed one of them would be the divergence this rule exists to
+  prevent.
+- **Path races** are tested by swapping a validated component for a symlink
+  between validation and commit, from a concurrent goroutine, and asserting
+  the write lands at the inode that was validated rather than at the swapped-in
+  target. The commit succeeding against the original is the point — a test that
+  asserts failure would be satisfied by an implementation that re-resolves at
+  commit time, which is the race itself.
+- **Conflict rejection** is tested per rule, in the vocabulary of the rules.
+  Same touched path: a `write` and a `delete` on one path, two `rename`s
+  sharing a source, a three-hop rename cycle, and a `fetch` whose `dest` is
+  another intent's path. Nesting: `write a` with `write a/b`, `rename a -> x`
+  with `rename a/b -> y`, and `delete a` with `rename a/b -> c`. Each asserts
+  whole-plan rejection naming the conflicting intents. The exception is tested
+  the other way round — `delete skills/foo` with `write skills/foo/SKILL.md`
+  must be accepted and must apply the delete first.
+- **Path equality** is tested on a case-insensitive filesystem: `write
+  README.md` with `delete Readme.md` is one path there and two on Linux, so
+  the same plan must be rejected on macOS and Windows and accepted on Linux.
+- **Delete rollback** is tested by failing the last write of a plan that
+  deletes a subtree and writes into it, asserting the subtree is back and the
+  earlier writes are gone.
+- **Audit log** is tested by asserting an applied plan logs every intent with
+  resolved paths, that a rejected plan logs the rule that rejected it, and
+  that no `content` body and no credential appears in the output.
+- **Dry-run** is tested by asserting `--dry-run` prints a tier-1 plan without
+  applying it, and refuses a tier-2 extension rather than running it.
+- **Remote policy** is tested with a redirect from an allowed host to a
+  private-range address, asserting the request is refused; with a cross-host
+  redirect, asserting the `Authorization` header is not replayed; with a
+  `POST` fetch intent, asserting whole-plan rejection at validation; and with a
+  name whose second resolution returns loopback, asserting the pinned address
+  is dialled rather than the rebound one.
 - **Confinement** is tested with purpose-built hostile modules — one that
   attempts to open `/etc/passwd`, one that attempts a socket, one that allocates
   without bound, one that never returns. Each must fail in the expected way, and

--- a/docs/dev-guide/design/extension-sandboxing.md
+++ b/docs/dev-guide/design/extension-sandboxing.md
@@ -38,7 +38,7 @@ capability for, and rejects the whole plan rather than applying it partially.
 | `write`  | `path`, `mode`, `content`                         | target extensions                |
 | `delete` | `path`                                            | target uninstall                 |
 | `rename` | `from`, `to`                                      | target migration between layouts |
-| `fetch`  | `url`, `method` (`GET`/`HEAD`), `headers`, `dest` | source extensions                |
+| `fetch`  | `url`, `method` (`GET`), `headers`, `dest`        | source extensions                |
 | `clone`  | `repo`, `ref`, `depth`, `dest`                    | git source extensions            |
 
 `fetch` and `clone` are executed by the host's own HTTP and `go-git` clients.
@@ -54,13 +54,17 @@ reach it. The policy is host-side and identical in both tiers.
 - **Schemes.** `https` for `fetch`; `https` or `ssh` for `clone`. Plain
   `http` is rejected rather than silently upgraded, so a downgrade is an
   error the author sees while authoring.
-- **Methods.** `fetch` carries `GET` or `HEAD` and nothing else. The plan's
-  atomicity guarantee covers the local tree, and a remote mutation cannot be
-  rolled back when a later intent fails, nor made safe to retry. Restricting
-  the method keeps the guarantee honest rather than qualifying it. An
-  extension that needs to write to a remote is out of scope for this protocol
-  and stays so until a capability with explicit idempotency and retry rules
-  is designed for it.
+- **Methods.** `fetch` carries `GET` and nothing else. The plan's atomicity
+  guarantee covers the local tree, and a remote mutation cannot be rolled back
+  when a later intent fails, nor made safe to retry. Restricting the method
+  keeps the guarantee honest rather than qualifying it. An extension that needs
+  to write to a remote is out of scope for this protocol and stays so until a
+  capability with explicit idempotency and retry rules is designed for it.
+
+  `HEAD` is excluded for a different reason. Every `fetch` carries a `dest`,
+  and a `HEAD` has no body to put there; since the extension never sees the
+  response either, a `HEAD` intent would have no observable effect at all. A
+  method the protocol cannot give a meaning is worse than one it omits.
 - **Destinations.** The host rejects loopback, link-local, and private-range
   addresses. The check runs against the resolved address, not the hostname,
   and runs again on every redirect hop. Whether an operator can re-admit a
@@ -78,6 +82,13 @@ reach it. The policy is host-side and identical in both tiers.
   time and a name that answered publicly once can answer `127.0.0.1` the
   second time. Pinning the dial to the checked address is what closes it, and
   it applies per hop.
+- **Transport authentication.** Pinning changes which address is dialled and
+  nothing else. The TLS handshake still verifies the certificate chain and the
+  hostname from the URL, not the pinned address, and a `clone` over `ssh`
+  verifies the host key before any credential is sent. Pinning is a
+  destination control and must never be mistaken for an identity one — an
+  implementation that dials an IP and lets the certificate follow it has
+  removed the guarantee this section exists for.
 - **Redirects.** Followed to a bounded depth, each hop validated and pinned as
   above. Credentials are attached per hop rather than carried across hops: a
   redirect that changes host drops every `Authorization` header and cookie
@@ -94,6 +105,12 @@ reach it. The policy is host-side and identical in both tiers.
   has no second call in which a response could be handed back. An extension
   that must branch on a status code or a header needs a request-side
   capability that does not exist yet, and is out of scope here.
+- **Bounds.** A remote operation is bounded in bytes and in time, host-side,
+  on the same reasoning as the plan bound: the extension does not perform the
+  effect, so it cannot be trusted to limit it either. A response or checkout
+  that exceeds its byte bound, or an operation that exceeds its deadline, is
+  abandoned and the whole plan fails. The values belong with the
+  implementation; what belongs here is that no remote operation is unbounded.
 - **Cache.** Keyed by extension identity as well as URL, so one extension
   cannot read another's fetched bytes out of a shared cache.
 
@@ -148,21 +165,30 @@ against itself, and the two writes are still judged against each other by rule
 two — one wants `a/b` to be a file, the other a directory, so the plan is
 rejected.
 
-`delete` on a path that does not exist is a no-op rather than an error, which
-is what makes two nested deletes safe: `delete a` with `delete a/b` produces
-the same tree whichever runs first, since the survivor finds nothing to do.
+`delete` on a path that does not exist is a no-op rather than an error. That
+alone does not make two nested deletes safe, because a missing path is not the
+only way the second one can fail: if `a` is a regular file, `delete a/b`
+returns `ENOTDIR` rather than `ENOENT`, so `delete a` with `delete a/b`
+would succeed in one order and fail in the other. Deletes are therefore
+applied ancestors before descendants, under the same path-equality relation
+the conflict rules use rather than a byte-wise sort — otherwise `delete
+Skills/Foo` and `delete skills/foo/bar` would not look nested on a
+case-folding filesystem and the descendant could still run first. `delete a`
+runs first, `delete a/b` then finds nothing and is a no-op, and the pair
+produces the same tree whatever order the extension emitted it in.
 
 Rejection is whole-plan and names the conflicting intents. There is no partial
 apply and no last-writer-wins.
 
-Surviving plans are applied deletes first, then renames, then writes, with
-`fetch` and `clone` ordered as writes since they produce content at a
-destination. Any two surviving intents that share or nest a path do so only
-because a `delete` excused them, and deletes run first, so no intent can
-remove or change the type of a path a later phase depends on, and the same
-plan produces the same tree on every host regardless of emission order. The
-ordering between kinds is fixed so that a plan is reproducible; it is not
-resolving conflicts, because nothing that reaches it conflicts.
+Surviving plans are applied deletes first — ancestors before descendants —
+then renames, then writes, with `fetch` and `clone` ordered as writes since
+they produce content at a destination. Any two surviving intents that share or
+nest a path do so only because a `delete` excused them, and deletes run first,
+so no intent can remove or change the type of a path a later phase depends on,
+and the same plan produces the same tree on every host regardless of emission
+order. The ordering between kinds, and between deletes within their phase, is
+fixed so that a plan is reproducible; it is not resolving conflicts, because
+nothing that reaches it conflicts.
 
 Replacing a subtree in one step is still not expressible. `rename staged ->
 skills/foo` alongside `write skills/foo/SKILL.md` is rejected, and there is no
@@ -182,11 +208,17 @@ root-relative paths.
 
 Validation and commit share a file descriptor rather than a path. The host
 opens the root once and resolves every plan path relative to that descriptor —
-with `openat2` under `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` on Linux, and
-elsewhere by walking the path one component at a time and refusing any
-component that is a symlink. A path is therefore never re-resolved between the
-check and the write, which is what makes a concurrent symlink swap
-unexploitable rather than merely unlikely.
+with `openat2` under `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_XDEV`
+on Linux, and elsewhere by walking the path one component at a time and
+refusing any component that redirects resolution. On Windows that means every
+reparse point, not only the ones that are symbolic links: a junction or a mount
+point redirects just as effectively and does not report itself as a symlink, so
+a check that asks only "is this a symlink" passes both. `RESOLVE_NO_XDEV` is in
+the Linux flag set for the same reason — without it a bind mount beneath the
+root is traversed on Linux and refused on Windows, which is precisely the
+per-platform divergence this rule exists to avoid. A path is therefore never
+re-resolved between the check and the write, which is what makes a concurrent
+symlink swap unexploitable rather than merely unlikely.
 
 Symlinks are not followed at all, on any platform. Following only the ones
 that stay beneath the root sounds narrower and is not expressible: under
@@ -230,11 +262,21 @@ above carries the guarantee.
 
 Every plan the host applies is logged before it is applied: the extension's
 identity and version, its tier, the capabilities it was granted, and every
-intent with its resolved paths. What the plan could not state in advance is
-appended as it happens — for `fetch` and `clone`, the address actually dialled
-at each redirect hop, which only exists once resolution and pinning have run.
+intent with its resolved paths, under a correlation id. What the plan could
+not state in advance is appended as it happens — for `fetch` and `clone`, the
+address actually dialled at each redirect hop, which only exists once
+resolution and pinning have run.
 Rejections are logged with the rule that rejected them. Content bodies are not
 logged; their hashes are.
+
+The outcome is logged too, after the fact, against the same correlation id as
+the pre-apply entry. There are three: committed; rolled back, naming the
+intent that triggered it; and rollback-failed, which means the tree is in
+neither the pre-plan nor the post-plan state. The third is the most important
+record the host can write and the reason the outcome is a distinct entry
+rather than a status appended to the first one. Without it a pre-apply entry
+reads as a change that landed when the plan may have been rolled back
+entirely, which makes the log actively misleading rather than incomplete.
 
 The log is the only control tier 2 has that tier 1 does not get for free. A
 tier-1 module cannot act outside its plan, so its log is a convenience. A
@@ -313,9 +355,16 @@ The child, in order:
    length exceeds the maximum plan size before copying anything, then writes
    it to stdout and exits.
 
-A child that exceeds any limit is killed and its output discarded without
-being parsed. Extension failure never leaves partial state, because nothing
-was applied.
+The three limits in steps 4 and 5 stop the module, not the child. The memory
+ceiling and the wall clock terminate the module's execution, the plan-size
+check refuses to copy an oversized plan out, and in each case the shim itself
+survives to report which limit was hit and exit cleanly. Reporting which limit
+was hit, rather than only that the child died, is why these limits sit inside
+the shim at all.
+A child is killed only by the host, and only two things do it: the stdout
+bound, and the outer deadline described below. The stderr cap does neither, so
+a plan is never discarded over a noisy log. Extension failure never leaves
+partial state, because nothing was applied.
 
 The maximum plan size is enforced twice, at two different layers, because
 there are two ways to overrun it. The shim applies it in step 5 against the
@@ -328,6 +377,34 @@ all: a tier-2 extension is an ordinary process on the other end of the same
 pipe, and an unbounded native writer would otherwise exhaust host memory or
 block it. Neither layer is redundant — the shim bound protects the shim, and
 the host bound is the only one a tier-2 extension ever meets.
+
+Bytes are not the only way a child can fail to finish, and tier 2 does not
+inherit the shim's clock. The wall-clock deadline in step 4 belongs to the
+shim and covers module execution only, so a tier-2 process has none at all,
+and a native extension that holds stdout open while writing nothing stays
+under every byte cap forever. The host therefore runs its own deadline against
+any child it launched, tier 1 or tier 2.
+
+That deadline is strictly the outer one. It starts at spawn and has to cover
+reading the artifact, applying confinement, the module's own budget, and the
+shim writing its result and exiting, so it cannot equal the step-4 value: set
+equal, the host would kill every shim at the instant the inner timeout fired
+and the clean "module timed out" diagnostic would never be produced. The byte
+bounds compose at equal values because the inner check short-circuits;
+deadlines do not, which is why this one is stated as an outer bound rather
+than the same bound applied twice. A child that exceeds it is killed as a
+process group and reaped, since a native extension can leave a grandchild
+holding the write end of a pipe that would otherwise never close.
+
+Stderr is bounded too, though not with the same remedy. The shim surfaces a
+child's stderr as diagnostics, so it is attacker-controlled output the host
+accumulates: it gets a byte cap, and a child that exceeds it has its
+diagnostics truncated with a marker and is allowed to continue, because losing
+the tail of a log is not a reason to discard an otherwise valid plan. The host
+keeps draining the pipe after the cap rather than stopping, since a reader
+that stops reading is what makes a child block on a full pipe. A bounded
+stdout beside an unbounded stderr would just move the problem to the other
+channel.
 
 ## Tiers
 
@@ -395,6 +472,10 @@ writes to stdout.
 - **Plan validation** is unit-tested against hostile inputs directly: `..`
   traversal, absolute paths, symlinks pointing outside the root, symlinks
   pointing inside it, and paths that only escape after the second resolution.
+- **Redirecting components** are tested per platform: on Windows a junction
+  and a mount point as a path component, on Linux a bind mount, asserting each
+  is refused rather than followed. A symlink-only check passes all three,
+  which is why they get their own cases rather than riding on the symlink one.
 - **Symlink policy** is tested on every platform and asserts the same outcome
   on each: a plan path traversing a symlink is rejected whether the link
   target is inside the root or outside it. Both cases are asserted precisely
@@ -421,17 +502,31 @@ writes to stdout.
 - **Delete rollback** is tested by failing the last write of a plan that
   deletes a subtree and writes into it, asserting the subtree is back and the
   earlier writes are gone.
+- **Delete ordering** is tested with `delete a` and `delete a/b` where `a` is a
+  regular file, asserting the plan applies in either emission order. Without
+  ancestors-first ordering the descendant delete returns `ENOTDIR`, so this
+  fails in exactly one of the two orders.
+- **Child lifecycle** is tested with a tier-2 extension that holds stdout open
+  and writes nothing, asserting the host kills and reaps it on the deadline
+  rather than waiting, and with one that floods stderr, asserting diagnostics
+  are truncated and the host neither blocks nor grows without bound.
 - **Audit log** is tested by asserting an applied plan logs every intent with
   resolved paths, that a rejected plan logs the rule that rejected it, and
-  that no `content` body and no credential appears in the output.
+  that no `content` body and no credential appears in the output. A plan that
+  rolls back is asserted to log the rollback against the same correlation id
+  as its pre-apply entry, so the pair cannot be read as a successful change.
 - **Dry-run** is tested by asserting `--dry-run` prints a tier-1 plan without
   applying it, and refuses a tier-2 extension rather than running it.
+- **Transport authentication** is tested by pinning a resolved address and
+  presenting a certificate valid for a different hostname, asserting the
+  handshake fails — pinning must not be able to launder a name mismatch.
 - **Remote policy** is tested with a redirect from an allowed host to a
   private-range address, asserting the request is refused; with a cross-host
   redirect, asserting the `Authorization` header is not replayed; with a
-  `POST` fetch intent, asserting whole-plan rejection at validation; and with a
-  name whose second resolution returns loopback, asserting the pinned address
-  is dialled rather than the rebound one.
+  `POST` fetch intent and with a `HEAD` one, asserting whole-plan rejection at
+  validation for both — `HEAD` is the method most likely to be waved through as
+  harmless; and with a name whose second resolution returns loopback, asserting
+  the pinned address is dialled rather than the rebound one.
 - **Confinement** is tested with purpose-built hostile modules — one that
   attempts to open `/etc/passwd`, one that attempts a socket, one that allocates
   without bound, one that never returns. Each must fail in the expected way, and


### PR DESCRIPTION
----
> 🦾 Written with LLM assistance [claude-opus-5]
> 💪 Reviewed by a human before submission
----

## Summary

Adds extension sandboxing ADR and its paired design doc. Extensions return a declarative *plan*
describing the effects they want, and the host validates and performs them,
instead of extensions writing files and opening sockets themselves.

Issue #42 is part of the motivation: install hooks already run automatically
with the user's permissions, so this is current behaviour rather than a
property of a future design.

The ADR is deliberately transport-agnostic. A plan is a payload shape rather
than a transport, so it holds over stdin/stdout or over go-plugin, and it takes
no position on the provider architecture proposed in #221.

<details>
<summary>How execution is tiered, and why Python is the exception</summary>

Tier 1 is WASM through `wazero`, for Go, Rust and JavaScript, by default.
Tier 2 is a signed, opt-in subprocess for Python, which cannot reach WASI
preview 1 without shipping a CPython interpreter.

`wazero` is chosen over `wasmtime-go` because it is pure Go with no cgo, which
preserves the single static binary and the one-step cross-compilation that
motivated the Go migration.

</details>

## Related Issues

Relates to #42, Relates to #175, Relates to #195, Relates to #221.

## Spec / ADR Reference

ADR: `docs/adr/extension-sandboxing.md`
Design: `docs/dev-guide/design/extension-sandboxing.md`

## Test Plan

Docs-only, so review is reading rather than running.

<details>
<summary>The load-bearing claims and where to check them</summary>

- [ ] The `go-plugin` quote in Context matches the upstream README, and scopes
      its isolation claim to memory space rather than to OS privilege
- [ ] wazero really is WASI preview 1 only, per <https://wazero.io/specs/>.
      That is why the Component Model is listed as deferred rather than
      rejected
- [ ] `wasmtime-go` really is cgo and x86_64-only, per its README. That is why
      it is disqualified, since it would drop Apple Silicon
- [ ] The tier table is consistent with the kinds `extension-architecture.md`
      reserves
- [ ] `mkdocs build --strict` reports the same two pre-existing
      `dev-guide/contributing.md` warnings as `main`, and the mermaid diagram
      in the design doc renders

</details>

## Checklist

<details>
<summary>Docs-only, so most items are N/A</summary>

- [x] Tests pass (`pytest` / `go test -race ./...`): N/A, docs only
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`): N/A
- [x] `go vet ./...` passes (Go changes only, N/A otherwise): N/A
- [x] Type checking passes (`uv run ty check`): N/A
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

</details>

## AI Disclosure

AI-assisted with Claude Code. The dependency evaluation behind the wazero and
go-landlock choices covered licence, release cadence, contributor distribution
and platform support. It was gathered from the GitHub API and upstream docs,
and is summarised in the ADR's Implementation Notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded extension sandboxing guidance with remote-access controls, capability restrictions, conflict handling, path safety, audit logging, execution limits, and testing coverage.
  * Clarified tier-specific behavior, including dry-run availability, approved network operations, execution boundaries, and legacy install-hook transition rules.
  * Documented protocol constraints, transport authentication requirements, audit outcomes, and updated dependency metadata.
* **Chores**
  * Added generated test output files to the repository’s ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->