### PR TITLE
docs: accept marketplace and repo as synonyms

### DIFF
--- a/docs/adr/extension-architecture.md
+++ b/docs/adr/extension-architecture.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-04-28
-**Last Updated**: 2026-05-29
+**Last Updated**: 2026-08-26
 **Authors**: Igor Brandao
 **Reviewers**:
 
@@ -22,13 +22,20 @@ for new capabilities without forking or modifying the Lola core binary.
 
 Introduce a formal extension system with the following extension kinds:
 
-| Kind | What it extends | Built-in examples |
-|------|----------------|-------------------|
-| `target` | Where skills are installed (assistant file formats and paths) | claude-code, cursor, gemini-cli, openclaw, opencode |
-| `repo` | Where skills are discovered (catalogs and registries) | yaml-catalog |
-| `runtime` | Where skills are executed (agent framework environments) | — (future) |
-| `source` | How skills are fetched (transport protocols) | git, zip, tar, folder |
-| `scan` | How skills are validated (security scanning) | — (future) |
+| Kind          | What it extends                                               | Built-in examples                                   |
+|---------------|---------------------------------------------------------------|-----------------------------------------------------|
+| `target`      | Where skills are installed (assistant file formats and paths) | claude-code, cursor, gemini-cli, openclaw, opencode |
+| `marketplace` | Where skills are discovered (catalogs and registries)         | yaml-catalog                                        |
+| `runtime`     | Where skills are executed (agent framework environments)      | — (future)                                          |
+| `source`      | How skills are fetched (transport protocols)                  | git, zip, tar, folder                               |
+| `scan`        | How skills are validated (security scanning)                  | — (future)                                          |
+
+The kind identifier `marketplace` is canonical, because a registry needs one
+key per kind. "Repository" and "repo" remain accepted synonyms in prose and as
+CLI aliases, in the same way `lola mod search` aliases `lola search --mod`.
+Aliasing the surface while keeping one identifier lets readers arriving from
+DNF, YUM or APT use the word they expect without making an extension manifest
+ambiguous about which kind it declares.
 
 Extensions will use a YAML manifest (`extension.yaml`) and a language-agnostic
 communication protocol. The detailed design — manifest schema, discovery flow,
@@ -47,7 +54,7 @@ once the Go project structure is established.
 ### Positive Consequences
 
 - Community can add support for new assistants without forking Lola
-- Custom skill catalogs are addable as repo extensions
+- Custom skill catalogs are addable as marketplace extensions
 - Security scanning is pluggable via scan extensions
 - Built-in and external extensions share the same interface contract
 

--- a/docs/dev-guide/architecture.md
+++ b/docs/dev-guide/architecture.md
@@ -7,7 +7,12 @@ While skills are becoming a standard for agent context (see [AgentSkills.io](htt
 Lola works similarly to [vim-plug](https://github.com/junegunn/vim-plug) for caching and installing, while mimicking the behavior of package managers like DNF, YUM, or APT for distribution and dependency management.
 
 !!! note
-    Lola currently uses the term "market" (or "marketplace") for its federated module catalogs. We are considering renaming this concept to "repository" or "repo" in a future release for better alignment with established package manager terminology.
+    Lola's federated module catalogs answer to two names. "Marketplace" is
+    canonical: it is what `lola market` and the `@marketplace/module` install
+    syntax already use, and what Claude Code and Cursor call the same concept.
+    "Repository" and "repo" are accepted synonyms, both in prose and as command
+    aliases, for readers coming from DNF, YUM or APT. Neither term is being
+    retired.
 
 ## How Lola Works
 


### PR DESCRIPTION
----
> 🦾 Written with LLM assistance [claude-opus-5]
> 💪 Reviewed by a human before submission
----

## Summary

The extension kind table in `extension-architecture.md` calls the catalog kind
`repo`, while `lola market`, the `@marketplace/module` install syntax and the
CLI reference all use the marketplace wording. This settles the kind identifier
on `marketplace`, and replaces the note in `dev-guide/architecture.md` that
said a rename to "repository" was under consideration with one that records the
outcome.

It does not retire "repository". Both names stay: one is the identifier,
because a kind registry needs a single key and an extension manifest should not
be ambiguous about the kind it declares. The other is an accepted synonym in
prose and as a CLI alias, which is what `lola mod search` already does for
`lola search --mod`. If the thread lands somewhere else, the identifier is one
line to change and the synonym does not move.

<details>
<summary>Where #48 currently sits</summary>

The thread has not converged on one word. @mrbrandao, who implemented the
marketplace, would prefer DNF-style "repositories". @mairin reads "marketplace"
as carrying a centralised connotation for something decentralised. @dmartinol
points out that Claude Code and Cursor both ship "marketplace". Accepting both
terms is what lets this PR settle the identifier without settling the thread.

</details>

## One conflict this PR does not resolve

ADR-0002 (`go-migration.md`) states the rename in the opposite direction. Its
Context says "The existing `market` terminology will be renamed to `repo`
during this migration", and its Positive Consequences repeats it. It cites
`dev-guide/architecture.md` as the source, which is the note this PR replaces.

That ADR is left untouched here. The decision belongs in #48, and amending
someone else's ADR from this PR would settle by edit what the thread has not
settled by discussion. If this lands, ADR-0002 wants a follow-up so the two
stop disagreeing.

## Related Issues

Relates to #48.

## Spec / ADR Reference

ADR: `docs/adr/extension-architecture.md`
Conflicts with: `docs/adr/go-migration.md` (ADR-0002), unedited, see above

## Test Plan

<details>
<summary>Four checks, all reading rather than running</summary>

- [ ] The kind table reads consistently with `docs/cli-reference/index.md`,
      which documents `lola market`
- [ ] ``grep -rn '`repo`' docs/`` finds no remaining use of `repo` as a kind
      name. The two hits in `go-migration.md` are the ADR-0002 conflict named
      above, not a kind identifier
- [ ] The note in `dev-guide/architecture.md` describes an outcome rather than
      an open question
- [ ] `mkdocs build --strict` reports the same two pre-existing
      `dev-guide/contributing.md` warnings as `main`, and no others

</details>

## Checklist

<details>
<summary>Docs-only, so most items are N/A</summary>

- [x] Tests pass (`pytest` / `go test -race ./...`): N/A, docs only
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`): N/A
- [x] `go vet ./...` passes (Go changes only, N/A otherwise): N/A
- [x] Type checking passes (`uv run ty check`): N/A
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

</details>

## AI Disclosure

AI-assisted with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that **Marketplace** is the canonical terminology for Lola’s federated module catalog.
  * Documented that **Repository** and **repo** remain supported synonyms in prose and command aliases.
  * Updated architecture guidance, command references, installation syntax, and related examples for consistency.
  * Refreshed the architecture decision record metadata and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->