### PR TITLE
docs(adr): add polyglot format handling

### DIFF
--- a/docs/adr/polyglot-formats.md
+++ b/docs/adr/polyglot-formats.md
@@ -1,0 +1,442 @@
+# ADR: Polyglot Format Handling
+
+**Status**: Proposed
+**Date**: 2026-08-25
+**Last Updated**: 2026-08-26
+**Authors**: trevor-vaughan
+**Reviewers**:
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+## Context
+
+Issue #179 asks for native support for Claude Code's plugin and marketplace
+formats, and states the alternative plainly: take the best ideas from Lola to
+[APM](https://github.com/microsoft/apm) instead, which already consumes the
+format. The issue names it as the single gap blocking adoption.
+
+That alternative has since closed. The [Go Migration](go-migration.md) ADR
+commits Lola to a Go single binary that imports skillimage's OCI packages and
+sigstore-go as compiled-in libraries; APM is a Python codebase. What is left to
+take from APM is its design work, not its runtime.
+
+Nothing in `docs/` mentions `.claude-plugin` or `marketplace.json`, and nothing
+in the source handles either. The gap is real. The question this ADR answers is
+what shape the fix takes.
+
+### The fan-out is the actual problem
+
+One publisher shows what supporting every client currently costs. The
+`superpowers` package, at 6.3.0, ships nine parallel manifests describing the
+same plugin:
+
+```text
+.claude-plugin/plugin.json
+.claude-plugin/marketplace.json
+.agents/plugins/marketplace.json
+.codex-plugin/plugin.json
+.cursor-plugin/plugin.json
+.devin-plugin/plugin.json
+.hermes-plugin/plugin.yaml
+.kimi-plugin/plugin.json
+gemini-extension.json
+```
+
+Nine hand-maintained descriptions of one artifact, drifting independently. This
+is the problem Lola was built for, one layer up: it already exists to stop
+authors writing the same context for Claude, Cursor and Gemini separately.
+Packaging metadata has landed in the same state.
+
+Answering #179 on its own terms produces a format ADR per client, which is that
+same trap with Lola inside it. Adapting every format onto one internal
+representation and rendering back out costs N+M instead of N×M. For the nine
+manifests in one package, that is 18 pieces against 72 pairwise conversions.
+
+### Documents this depends on
+
+Two ADRs referenced below are in flight on their own branches and are not on
+`main` yet. §6 needs the first for content template confinement; §5 needs the
+second for why the verb is `export` and not `publish`.
+
+| Reference            | Branch                     | Cited in |
+|----------------------|----------------------------|----------|
+| Extension Sandboxing | `adr/extension-sandboxing` | §6       |
+| CLI Verb Conventions | `adr/cli-verb-conventions` | §5       |
+
+This ADR also calls the catalog extension kind `marketplace`, which `main`
+still names `repo`; that rename is the `docs/marketplace-terminology` PR.
+
+Merging this one first leaves those links dangling until the others land, so
+merge them first or read the names as the ones they are taking.
+
+### The formats are distinguishable
+
+Package manifests sit on the top row, catalog manifests on the bottom:
+
+| Agent Plugins                      | Claude Code                       |
+|------------------------------------|-----------------------------------|
+| `plugin.json` at root              | `.claude-plugin/plugin.json`      |
+| `.agents/plugins/marketplace.json` | `.claude-plugin/marketplace.json` |
+
+The catalogs identify themselves differently too. Agent Plugins keys on
+`interface`, `name` and `plugins`; Claude Code on `name`, `owner`,
+`description` and `plugins`. Per-entry, Agent Plugins carries a `policy` block
+covering installation and authentication, where Claude Code carries `category`,
+`homepage` and `renames`.
+
+The paths never collide, so detection is unambiguous, and a package that ships
+both is ordinary.
+
+Package manifests in the wild are thin. Across 26 installed plugins, every one
+carried `name`, `description` and `author`; nine carried `version`; three
+`homepage`; two each `repository`, `license` and `keywords`. No plugin declared
+component paths. Commands, agents and skills are discovered by convention,
+which is close to how Lola already discovers module content.
+
+## Decision
+
+Lola adapts any packaging format in, normalises onto `lola.yml`, and renders
+back out through target-aware templates.
+
+```text
+  ANY PACKAGE         NORMALIZE (once, at mod add)    EXPORT (on demand)
+
+  .claude-plugin/ ─┐                                 ┌─→ .claude-plugin/
+    plugin.json    │  ┌───────────────────────────┐  │
+                   ├─→│ adapter → scan → lola.yml │──┼─→ .agents/plugins/
+  plugin.json      │  │      + .lola-origin       │  │
+    (Agent Plugins)│  └───────────────────────────┘  └─→ gemini-extension.json
+                   │        ~/.lola/modules/             …
+  lola.yml ────────┘
+```
+
+### 1. `lola.yml` is the intermediate representation
+
+Every format Lola reads is adapted onto `lola.yml`. Lola keeps its own format
+as the native one because `lola.yml` carries the target matrix that installs a
+single module to five assistants, and no client format has a field for it.
+Adopting a client format as native would cap what a Lola module can say at
+whatever that client happens to support.
+
+To hold what it reads, `lola.yml` grows the package-metadata layer it never
+had: `version`, `author`, `license`, `homepage`, `keywords` and `repository`,
+all optional. This is not new scope. The Claude adapter spec already maps
+`version`, `author` and `license` outward as though they exist, while `Module`
+in the source defines none of them. The dependency is already load-bearing and
+undeclared.
+
+Fields that recur across formats are promoted to first class. Vendor-specific
+residue is preserved verbatim in a `formats` block keyed by format id, so
+exporting that format restores it. Nothing is silently discarded on the way in.
+
+`formats` is a deliberate name, chosen over `x-format`. Foreign data held
+inside Lola's own schema is a different thing from Lola injecting keys into
+someone else's schema, and the name should not blur the two.
+
+### 2. A target extension owns its client's format in both directions
+
+The claude-code target extension knows how to read `.claude-plugin/plugin.json`
+and how to emit it. One extension per client, ingest and export together.
+
+This adds no sixth extension kind;
+[Extension Architecture](extension-architecture.md)'s five stand as written,
+and it is what the #200 / #201 / #202 series is building toward. A new tool
+ships one bundle and gets read and write, rather than needing an adapter
+registered in one place and a template in another.
+
+Catalogs stay separate. `.claude-plugin/marketplace.json` is read by a
+`marketplace` extension alongside the built-in `yaml-catalog`, because a
+catalog describes many packages and a target describes one client. Claude Code
+therefore contributes two extensions, one of each kind.
+
+Adding a target must leave core unchanged: the adapter dispatch, the normalise
+step, the IR schema and the export driver are untouched by target N+1. If a new
+target does need a core change, that is a finding about the extension
+interface, and it gets written up as one.
+
+### 3. Normalisation happens once, at `mod add`
+
+`lola mod add` runs the adapter once and writes the normalised `lola.yml` into
+the module cache. The source package is never mutated implicitly. `lola mod
+convert` writes `lola.yml` into a package in place, for publishers who want to
+migrate, and runs only when asked.
+
+Normalising at add time settles the security boundary and the precedence
+decision once. Doing it per read re-opens both on every operation.
+
+### 4. Precedence is decided once and recorded
+
+When a source root carries more than one recognised manifest, first match wins
+and nothing merges:
+
+```text
+1. lola.yml                      Lola's own
+2. plugin.json (at root)         Agent Plugins
+3. .claude-plugin/plugin.json    Claude Code
+```
+
+Merging would make the resulting module depend on which formats a package
+happened to ship, which is not reproducible.
+
+The choice is reported on add and recorded in `.lola-origin` beside the
+normalised manifest, along with the format id, the source `sha` where the
+catalog supplied one, and the scan verdict. Silent precedence is the failure
+mode here, and a file someone can read is a better answer than a rule they have
+to remember.
+
+### 5. Export is template-driven and explicit
+
+`lola mod export --target <id>` renders the client manifests from the IR.
+Target selection is required and `--all` exports every format the module
+declares; neither form has a bare default, because the point of an explicit
+verb is defeated by one that guesses which files to write.
+
+Export never runs as a side effect of install. A package manager that rewrites
+a developer's context files unasked is one they stop trusting.
+
+`publish` is reserved for pushing to a catalog or registry. In npm and cargo it
+means upload, Lola's target list includes OCI registries, and CLI Verb
+Conventions (proposed separately) settles canonical names by what the surveyed
+managers actually do.
+
+Manifests render as data, not as interpolated text. A template produces a data
+structure, Lola marshals it and validates against the vendored schema before
+writing, so a template cannot emit a stray comma into another vendor's
+`plugin.json`. Where a target format supports a reference, the exporter emits
+the reference and leaves the content where it is.
+
+Where a target format requires a field the module does not carry, export
+refuses and names both the field and the target. Lola does not synthesise a
+value: a `0.0.0` version means something false downstream, and a wrong value is
+worse than a missing one.
+
+### 6. Untrusted templates run with an empty capability grant
+
+Content templates are authored by publishers and arrive inside modules pulled
+from catalogs. They run confined under Extension Sandboxing (proposed
+separately) as tier-1 WASM with no granted capabilities. Target templates ship
+with Lola or with a target extension and need no confinement.
+
+One engine and one dialect throughout; the grant varies by origin. A second
+reduced dialect for untrusted templates would be a second thing to write,
+document and keep in sync with the first.
+
+Extension Sandboxing's guarantee is that effects are host-mediated: an
+extension returns a declarative plan and the host performs the effects after
+checking them against granted capabilities. A content template containing
+`{{ exec ... }}` therefore does not execute and get contained. It produces a
+capability request the host refuses. The residual risk is a runtime escape
+rather than template-level code execution.
+
+## Rationale
+
+- **Fan-out**: the argument was already in this ADR, applied only halfway. Nine
+  manifests make the case for adapters and templates. They do not make the case
+  for a tenth hand-written reader.
+- **Reach, not identity**: reading more formats widens what Lola can install.
+  Replacing its own would narrow what Lola can say. The two get confused.
+- **The extension kinds already exist**: targets own their formats, and
+  catalogs are a `marketplace` extension. Both are the first real exercises of
+  the Extension Architecture interface, which is how third-party authors learn
+  whether it generalises.
+- **Export is the hard half**: APM already consumes Anthropic's format. Nine
+  manifests in one repository is the evidence that consumption alone leaves the
+  publisher's problem untouched.
+- **Catalog network effect**: 286 plugins in one official marketplace is a
+  corpus Lola can install from the day this lands, and a conformance corpus for
+  the adapter.
+- **One security boundary**: normalising once gives untrusted content a single
+  way into Lola's representation, which is the one place the `scan` kind has to
+  hook.
+
+## Consequences
+
+### Positive Consequences
+
+- Every plugin in a Claude Code marketplace becomes installable by Lola,
+  including to targets that are not Claude Code
+- A publisher can maintain one source and export the client manifests, instead
+  of hand-editing nine
+- A new tool costs one extension bundle, where today it costs an ADR, a reader,
+  an emitter and a release
+- Round-trip fidelity becomes a test rather than a promise, because nothing is
+  dropped silently on the way in
+- Precedence and the scan verdict become inspectable facts in `.lola-origin`
+  instead of behaviour someone has to reproduce to understand
+- Extension Architecture's `scan` kind gets its first concrete justification
+
+### Negative Consequences
+
+- `lola.yml` grows a metadata layer, and every adapter that follows will put
+  pressure on it again
+- The `formats` passthrough is somewhere unmapped data can hide, and a bug there
+  is invisible until an export produces the wrong file
+- Anthropic's format is defined by a schema URL Lola does not control and can
+  change without notice; validation has to tolerate unknown fields
+- Exporting means Lola makes claims about other clients' formats, and a format
+  Lola gets wrong produces a package that fails on someone else's tool
+- Content templating cannot ship until Extension Sandboxing's tier-1 host
+  exists, so #195 is gated on work this ADR does not own
+- Three package manifests and two catalog formats is real surface area, and each
+  one needs its own conformance tests
+
+## Alternatives Considered
+
+### Alternative 1: A format ADR per client
+
+- Description: Answer #179 for Claude, then repeat for Codex, Cursor, Devin,
+  Hermes and Gemini as each is asked for.
+- Pros: Each decision is small, concrete, and driven by a real request.
+- Cons: N×M work, and six documents that each re-decide precedence, lossiness
+  and emission slightly differently. It is the drift this ADR complains about,
+  reproduced inside Lola's own documentation.
+- Reason for rejection: The original draft of this ADR was that document, and
+  writing it made the general rule obvious.
+
+### Alternative 2: Adopt Anthropic's format as Lola's native one
+
+- Description: Replace `lola.yml`, as #179 asks.
+- Pros: Immediate compatibility; no translation; the largest existing catalog.
+- Cons: Lola's target matrix has no equivalent field, so the multi-assistant
+  install that distinguishes Lola would have to move into a vendor extension of
+  someone else's schema.
+- Reason for rejection: It trades the reason Lola exists for the format's reach,
+  and the reach is available by reading it.
+
+### Alternative 3: Normalise lossily and report the drop
+
+- Description: Map what maps, discard the rest, tell the user what was lost.
+- Pros: A clean IR with no vendor baggage, and ingest behaves symmetrically with
+  export.
+- Cons: `import → export` is not identity, so a publisher who runs Lola over an
+  existing `.claude-plugin/` silently loses `category` on the first cycle.
+- Reason for rejection: Export exists so publishers can maintain one source. A
+  converter that damages the thing it converts cannot sit in that loop.
+
+### Alternative 4: Contribute to APM instead
+
+- Description: #179's own stated alternative.
+- Pros: Larger project, more momentum, one ecosystem rather than two. It has
+  already shipped a lockfile, an install-time policy file and a generated
+  conformance statement.
+- Cons: APM is Python, installed as a bundled archive with a pip fallback that
+  needs a Python 3.9 runtime. Lola is leaving Python for a Go binary that links
+  skillimage and sigstore-go directly, and neither has a Go seam inside APM to
+  contribute against.
+- Reason for rejection: The two projects no longer share a runtime, so this
+  stopped being a question of scope and became one of language. The design can
+  still cross over, and it is borrowed below.
+
+### Alternative 5: Treat `.claude-plugin/` as an Agent Plugins namespace
+
+- Description: Read it through the `com.anthropic.claude-code` namespace the
+  merged Agent Plugins ADR already handles.
+- Pros: No new detection path.
+- Cons: The namespace mechanism reads component paths *inside* an Agent Plugins
+  package. A Claude-only package has no Agent Plugins manifest to hang them on.
+- Reason for rejection: The two formats are siblings, not one nested in the
+  other.
+
+## Implementation Notes
+
+Phase 1 is adapters, normalisation and target templates. It has no sandbox
+dependency because the templates are Lola's own, and it closes #179.
+
+Phase 2 is content templates. It cannot start before Extension Sandboxing's
+tier-1 WASM host exists, and it closes #195.
+
+Reading comes first within phase 1 and stands alone:
+
+1. Adapt `.claude-plugin/plugin.json` onto the IR. Discovery by convention;
+   unknown manifest fields warn, are preserved in `formats`, and never fail the
+   parse.
+2. Add `claude-marketplace`, a `marketplace` extension reading
+   `.claude-plugin/marketplace.json`, covering all three `source` shapes. Build
+   it against the extension interface with no core changes, and treat any core
+   change it needs as a finding about Extension Architecture.
+3. Implement precedence, write `.lola-origin`, and report the manifest used.
+4. Export last, one target format per change, starting with `.claude-plugin/`
+   and the Agent Plugins layout. The other five are named but not committed to
+   here.
+
+Conformance fixtures come from real packages. Hand-written examples encode the
+assumptions they are supposed to test. The official catalog and its 286 entries
+are the obvious corpus, and `superpowers` gives the adapter a package described
+by two catalog formats at once, `.claude-plugin/marketplace.json` and
+`.agents/plugins/marketplace.json`.
+
+Precedence is the one rule the corpus cannot exercise. Every one of the 26
+packages surveyed carries `.claude-plugin/plugin.json` and none carries a root
+`plugin.json`, so no real package reaches the second rung of §4's ladder. That
+fixture has to be constructed, and the test suite should say plainly that it is
+synthetic.
+
+The schema URL is not fetched at install time. Validate against a vendored copy
+on a known cadence, the same way the Agent Plugins ADR validates locally
+without retrieving its schema.
+
+### Borrowed from APM
+
+APM reached several of these problems first and published its answers. Five
+carry over even though the codebase cannot:
+
+1. **Export is an explicit verb.** APM writes agent files on `apm compile`,
+   with `--target` choosing which, rather than as a side effect of install.
+   §5 works the same way and for the same reason.
+2. **Emit references where the format allows one.** For Claude Code, APM writes
+   `@apm_modules/...` pointers instead of inlining bodies. Inlined content is
+   the copy that drifts.
+3. **Pin what the catalog already hands you.** `apm.lock.yaml` records an
+   integrity hash per entry. Anthropic's `git-subdir` source carries `sha` for
+   free, and `.lola-origin` records it.
+4. **Scan what gets installed.** APM checks every install for hidden Unicode.
+   Extension Architecture already reserves a `scan` kind and lists no
+   implementation for it. Installing from a 286-entry catalog nobody here
+   curates is the case that justifies the first one, because the payload is
+   instructions to an agent and the agent is the thing that runs them.
+5. **Publish a conformance statement, not a conformance claim.** APM generates
+   `CONFORMANCE.md` from its own suite, marking each requirement active,
+   skipped or xfail and writing out a waiver for every skip. Three package
+   manifests and two catalog formats is the situation that needs the same
+   discipline: say per format what is tested, and admit what is not.
+
+Not borrowed here: APM's `apm-policy.yml` install policy. It is a good idea and
+belongs to a different ADR than this one.
+
+### Out of scope
+
+- **Templating engine selection.** This ADR says template-driven, not `jet`.
+  The engine is its own decision, gated behind dependency vetting.
+- **Module identity across catalogs.** Stays with #177, which owns the case
+  where several `#subdirectory=` entries share one repository URL.
+- **Install policy.** See the note above.
+- **The remaining five export formats.** Named, not committed.
+
+## References
+
+- Issue #179 — native support for the Claude Code plugin format
+- Issue #195 — inline templating, closed by phase 2
+- Issue #232 — Agent Plugins spec support, satisfied by
+  [agent-plugins-format.md](agent-plugins-format.md)
+- Issue #177 — module naming across catalogs
+- Issues #200, #201, #202 — the target extension series this builds on
+- [Claude adapter](../dev-guide/design/claude-adapter.md) — the first adapter
+- [Polyglot formats design](../dev-guide/design/polyglot-formats.md) — IR
+  schema, normalisation and capability grants
+- [ADR: Support the Agent Plugins Format](agent-plugins-format.md) — the
+  vendor-neutral sibling format
+- [ADR: Extension Architecture](extension-architecture.md) — the `target`,
+  `marketplace` and `scan` kinds this uses
+- ADR: Extension Sandboxing, proposed separately — confinement for content
+  templates
+- ADR: CLI Verb Conventions, proposed separately — why `export` and not
+  `publish`
+- [ADR: Go Migration](go-migration.md) — why contributing to APM is closed
+- [Agent Plugins specification](https://agent-plugins.org/)
+- [APM](https://github.com/microsoft/apm) — the alternative named in #179, and
+  the source of the lessons above
+- [APM conformance](https://github.com/microsoft/apm/blob/main/CONFORMANCE.md)
+  — the per-requirement statement the fifth borrowed lesson points at

--- a/docs/dev-guide/design/claude-adapter.md
+++ b/docs/dev-guide/design/claude-adapter.md
@@ -1,0 +1,164 @@
+# Claude Code Adapter
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+Implementation detail for
+[ADR: Polyglot Format Handling](../../adr/polyglot-formats.md), and the first
+adapter written under it. The ADR owns the decision and
+[polyglot-formats.md](polyglot-formats.md) owns the IR, normalisation,
+precedence and the export pipeline. This document owns Claude Code's field
+mappings and what an export to Claude's formats may and may not claim.
+
+Every shape below was read from installed packages rather than from a
+specification, so treat it as an observation of the format in use. The
+authoritative schema is at
+`https://anthropic.com/claude-code/marketplace.schema.json`, which
+`marketplace.json` names in its own `$schema` field.
+
+## Package manifest
+
+`.claude-plugin/plugin.json`. Observed across 26 installed plugins:
+
+| Field | Seen in | Maps to |
+|-------|---------|---------|
+| `name` | 26 / 26 | module identity |
+| `description` | 26 / 26 | module description |
+| `author` | 26 / 26 | object with `name`, optional `email` |
+| `version` | 9 / 26 | module version; absent means unversioned |
+| `homepage` | 3 / 26 | metadata only |
+| `repository` | 2 / 26 | metadata only |
+| `license` | 2 / 26 | metadata only |
+| `keywords` | 2 / 26 | search terms |
+
+No observed plugin declared component paths. Commands, agents and skills are
+found by convention, which is how Lola already discovers module content, so
+discovery needs no new mechanism — only the directory names Claude Code uses.
+
+Absent fields are the common case rather than the exception. Two thirds of real
+plugins carry no `version`. Treat everything but `name` as optional and do not
+reject a manifest for omitting metadata.
+
+## Catalog manifest
+
+`.claude-plugin/marketplace.json`. Top-level keys observed: `$schema`, `name`,
+`owner`, `description`, `plugins`, `renames`.
+
+Each entry in `plugins` carries `name`, `description`, `author`, and a `source`,
+with optional `category` and `homepage`. In the official catalog of 286 entries,
+`source` takes three shapes:
+
+| Shape | Count | Meaning | Existing Lola handler |
+|-------|-------|---------|----------------------|
+| `{"source": "url", "url": ...}` | 150 | fetch from a URL | url / archive |
+| `{"source": "git-subdir", "url", "path", "ref", "sha"}` | 83 | a subdirectory of a git repo at a pinned ref | git with `#subdirectory=` |
+| bare string | 53 | shorthand for a URL | url |
+
+All three map onto source handling Lola already has. `git-subdir` is the one
+worth care: it carries both `ref` and `sha`, and the `sha` is what should be
+recorded for integrity. It also collides with the naming problem in issue #177,
+where several `#subdirectory=` entries share one repository URL.
+
+`renames` appears at catalog level and records plugins that changed name.
+Reading it lets an installed module survive an upstream rename instead of
+looking like a removal followed by an unrelated addition.
+
+## Comparison with Agent Plugins
+
+Lola already reads the vendor-neutral format. The differences that matter here:
+
+| | Agent Plugins | Claude Code |
+|---|---|---|
+| Package manifest path | `plugin.json` at root | `.claude-plugin/plugin.json` |
+| Catalog manifest path | `.agents/plugins/marketplace.json` | `.claude-plugin/marketplace.json` |
+| Catalog top level | `interface`, `name`, `plugins` | `name`, `owner`, `description`, `plugins`, `renames` |
+| Per-entry extras | `policy.installation`, `policy.authentication` | `category`, `homepage` |
+| Extension mechanism | reverse-domain namespaces | none observed |
+
+The paths never collide, so detection is unambiguous. A package carrying both is
+normal rather than a conflict: `superpowers` ships both.
+
+Agent Plugins `policy` has no Claude equivalent. When emitting Agent Plugins
+output from a Lola module there is nothing to derive it from, so omit it rather
+than defaulting it — a wrong `authentication` value is worse than a missing one.
+
+## Precedence
+
+Claude's manifest sits third, behind `lola.yml` and the Agent Plugins root
+`plugin.json`. The rule itself and its reporting are general and live in
+[polyglot-formats.md](polyglot-formats.md#precedence).
+
+`superpowers` is the fixture that exercises it, since it ships both an Agent
+Plugins manifest and a Claude one, and the two paths never collide.
+
+## Ingest and export mapping
+
+The same table read in both directions. Ingest fills IR fields from the
+manifest; `lola mod export --target claude-code` fills the manifest from the
+IR.
+
+| IR field | `.claude-plugin/plugin.json` |
+|----------|------------------------------|
+| `name` | `name` |
+| `description` | `description` |
+| `version` | `version` |
+| `author` | `author.name`, `author.email` |
+| `license` | `license` |
+| `homepage` | `homepage` |
+| `repository` | `repository` |
+| `keywords` | `keywords` |
+| `formats.claude-code.category` | `category` (catalog entries) |
+| `targets` | **no equivalent** |
+| install hooks | **no equivalent** |
+
+`category` has no first-class IR field because nothing outside Claude's catalog
+uses it, so it round-trips through `formats.claude-code`. Everything above it
+recurs across formats and is promoted.
+
+`targets` is the field that makes a Lola module install to five assistants, and
+no client format has a home for it. An exported manifest is therefore a
+narrower artifact than the module it came from, and export says so once rather
+than implying fidelity it cannot deliver.
+
+Claude's package manifest requires only `name`, so export to this format never
+fails for a missing required field. Two thirds of the corpus omits `version`,
+and an export that omits it is well-formed.
+
+Claude declares no vendor extension mechanism, and Lola does not invent one.
+See [polyglot-formats.md](polyglot-formats.md#what-export-does-not-claim) for
+why.
+
+## Schema handling
+
+Do not fetch `https://anthropic.com/claude-code/marketplace.schema.json` at
+install time. An installer that makes a network call to validate is an installer
+that fails offline and leaks what is being installed.
+
+Vendor a copy, validate against it, and refresh on a deliberate cadence. Unknown
+fields warn and are ignored, which is what the Agent Plugins ADR already does
+and what lets a catalog add a field without breaking every older Lola.
+
+## Testing
+
+Fixtures come from real packages. Hand-written examples encode assumptions
+rather than testing them.
+
+Adapter-specific cases:
+
+- Every `source` shape in the official catalog resolves: bare string, `url`, and
+  `git-subdir` with `ref` and `sha`
+- A `git-subdir` entry records the `sha` in `.lola-origin` alongside the `ref`
+- A manifest with only `name`, `description` and `author` is accepted, since
+  that is two thirds of the corpus
+- A catalog `renames` entry maps an installed module to its new name rather than
+  reporting a removal
+- `category` survives a round-trip through `formats.claude-code`
+- Exporting `.claude-plugin/` from a module with `targets` set omits `targets`
+  and reports it
+
+Precedence, unknown-field handling, round-trip equality and the offline
+validation requirement are general and tested against the list in
+[polyglot-formats.md](polyglot-formats.md#testing). The 286-entry catalog is
+the corpus for both.

--- a/docs/dev-guide/design/polyglot-formats.md
+++ b/docs/dev-guide/design/polyglot-formats.md
@@ -1,0 +1,254 @@
+# Polyglot Format Handling
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+Implementation detail for
+[ADR: Polyglot Format Handling](../../adr/polyglot-formats.md). The ADR owns
+the decision; this document owns the IR schema, the normalisation algorithm,
+the capability grants, and what round-trip means.
+
+Per-format field mappings live with each adapter. The first one is the
+[Claude adapter](claude-adapter.md).
+
+## The intermediate representation
+
+`lola.yml` is what every adapter produces and every template consumes.
+
+| Field         | Type                             | Required | Source                     |
+|---------------|----------------------------------|----------|----------------------------|
+| `name`        | string                           | yes      | module identity            |
+| `description` | string                           | no       |                            |
+| `version`     | string                           | no       | absent means unversioned   |
+| `author`      | object: `name`, optional `email` | no       |                            |
+| `license`     | SPDX identifier string           | no       |                            |
+| `homepage`    | URL string                       | no       |                            |
+| `repository`  | URL string                       | no       |                            |
+| `keywords`    | list of strings                  | no       | search terms               |
+| `targets`     | list of target ids               | no       | the multi-assistant matrix |
+| `formats`     | map of format id to object       | no       | passthrough residue        |
+
+Only `name` is required. Two thirds of the 26 surveyed Claude plugins carry no
+`version`, and a manifest is never rejected for omitting metadata.
+
+`targets` is the field that makes a Lola module install to five assistants. No
+client format has a home for it, which is the concrete reason the ADR declines
+to adopt one of them as native.
+
+### The `formats` passthrough
+
+Fields an adapter reads but the IR has no first-class home for are preserved
+verbatim, keyed by format id:
+
+```yaml
+formats:
+  claude-code:
+    category: workflow
+    renames: {old-name: superpowers}
+  agent-plugins:
+    policy: {installation: ..., authentication: ...}
+```
+
+Rules:
+
+- An adapter writes only under its own format id. Cross-writing is a bug.
+- Values are stored as read. No coercion, no defaulting, no normalisation.
+- The exporter for a format reads that format's block back and nothing else. A
+  Claude export never consults the `agent-plugins` block.
+- A field promoted to first class in a later release moves out of `formats` and
+  the adapter stops writing it there. That is a breaking change to the cached
+  representation and needs a cache version bump.
+
+The name is `formats`, not `x-format`. The Claude adapter argues against
+`x-`-prefixed vendor extensions in someone else's schema; foreign data held
+inside Lola's own schema is a different thing, and the name should not blur the
+two.
+
+## `.lola-origin`
+
+Written beside the normalised `lola.yml` in the module cache. Records what
+normalisation decided, so none of it has to be re-derived or remembered.
+
+```yaml
+format: claude-code                  # which adapter ran
+manifest: .claude-plugin/plugin.json # which file won precedence
+others_present:                      # what else was there, and ignored
+  - .agents/plugins/marketplace.json
+sha: 4f2c1ab...                      # from the catalog entry, where supplied
+scan:
+  extension: unicode-guard
+  verdict: clean
+  at: 2026-08-26T14:02:11Z
+```
+
+`sha` comes free from Claude's `git-subdir` source shape, which supplies it for
+83 of the 286 entries in the official catalog. Recording it costs nothing and
+is the integrity pin APM's lockfile pays for separately.
+
+## Normalisation
+
+Runs once, on `lola mod add`. The source package is never mutated.
+
+1. Fetch content into the module cache through the existing `source` handlers.
+2. Detect every recognised manifest at the source root.
+3. Apply precedence. Record the winner and the others in `.lola-origin`.
+4. Run the `scan` extension over the fetched content. A failed scan aborts the
+   add; the cache entry is not written.
+5. Run the winning format's adapter. Mapped fields become IR fields; unmapped
+   fields go to `formats` under that adapter's id.
+6. Write `lola.yml` and `.lola-origin` into the cache entry.
+
+`lola mod convert <path>` runs steps 2 through 5 against a package in place and
+writes `lola.yml` into it. It is the only operation that writes into a package
+Lola did not fetch, and it runs only when invoked directly.
+
+### Precedence
+
+First match wins. Nothing merges.
+
+```text
+1. lola.yml                      Lola's own
+2. plugin.json (at root)         Agent Plugins
+3. .claude-plugin/plugin.json    Claude Code
+```
+
+Merging would make the resulting module depend on which formats a package
+happened to ship, which is not reproducible.
+
+Report the choice on every add: `using .claude-plugin/plugin.json (2 other
+manifests present)`. Someone who adds a Claude manifest to a package that
+already has `lola.yml` and sees no change needs to be told why.
+
+### Round-trip
+
+`import <format>` followed by `export <format>` is **semantically identical**,
+not byte-identical. Key order, indentation and whitespace are not preserved;
+parsed-equal is the test.
+
+Byte-identity is a promise the YAML and JSON serialisers cannot keep, and
+asserting it produces a test that fails for reasons nobody cares about.
+
+The claim covers **manifests only**. Skill bodies are copied verbatim and are
+not part of it.
+
+## Templates
+
+Two populations, one engine, one dialect. The capability grant varies by
+origin.
+
+|              | Target templates            | Content templates                                               |
+|--------------|-----------------------------|-----------------------------------------------------------------|
+| Author       | Lola, or a target extension | module publisher                                                |
+| Arrives from | the installed toolchain     | a catalog                                                       |
+| Renders      | IR → client manifest        | per-target variation in skill markdown                          |
+| Grant        | trusted, host-side          | empty                                                           |
+| Confinement  | none needed                 | tier-1 WASM, Extension Sandboxing (proposed separately)         |
+
+A content template that requests any capability is refused by the host, not
+contained and then run. Extension Sandboxing's guarantee is that effects are
+host-mediated: the template returns a plan, the host checks it against the
+grant, and an empty grant means every requested effect is denied.
+`{{ exec ... }}` in a catalog-sourced template produces a refusal, not a
+subprocess.
+
+Keeping one dialect and varying the grant puts the restriction in a single
+enforcement point. A second reduced dialect for untrusted templates would be a
+second thing to write, document and keep in sync with the first.
+
+## Export
+
+`lola mod export --target <id>` renders one format. `--all` renders every
+format in the module's `targets`. Neither has a bare default.
+
+The render pipeline is structured, never textual:
+
+```text
+IR + formats[id]  →  template  →  data structure
+                                       │
+                                       ├→ marshal (JSON or YAML)
+                                       ├→ validate against vendored schema
+                                       └→ write
+```
+
+A template produces a data structure, so it cannot emit a stray comma into
+another vendor's manifest. Invalid structure fails at marshal. Unknown fields
+warn at validate and are written, because a client adding a field should not
+break an older Lola.
+
+Where a target format supports a reference, emit a reference rather than an
+inlined copy. Inlined content is the copy that drifts.
+
+### Required fields
+
+Where a target format requires a field the module does not carry, export
+refuses and names both the field and the target:
+
+```text
+cannot export superpowers to codex: format requires `version`,
+module has none. Set it in lola.yml or export to a format that
+does not require it.
+```
+
+Lola does not synthesise a value. A `0.0.0` version means something false
+downstream, and a wrong value is worse than a missing one.
+
+### What export does not claim
+
+An exported manifest is a narrower artifact than the module it came from.
+`targets` and install hooks have no home in any client format, and export says
+so once rather than implying fidelity Lola cannot deliver.
+
+Do not invent vendor extensions to carry what does not fit. An `x-lola-targets`
+key in someone else's schema is a private convention wearing a standard's
+clothes, and it will not survive their next schema revision.
+
+## The adapter contract
+
+A target extension supplies four things. Adding one leaves the adapter
+dispatch, the normalise step, the IR schema and the export driver unchanged.
+
+| Artifact             | Direction     | Contract                                            |
+|----------------------|---------------|-----------------------------------------------------|
+| ingest adapter       | manifest → IR | maps known fields, routes the rest to `formats[id]` |
+| export template      | IR → manifest | returns a data structure, never text                |
+| target descriptor    | —             | content paths, required fields, capability grant    |
+| conformance fixtures | —             | a real package and its expected round-trip          |
+
+Any core change a new target needs is a finding about the extension interface,
+and belongs in a note on Extension Architecture rather than in a quiet patch.
+
+## Testing
+
+Fixtures come from real packages. Hand-written examples encode assumptions
+rather than testing them. The official Claude catalog and its 286 entries are
+the corpus; `superpowers` is the ready-made dual-catalog case, since it ships
+both `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`
+for the same package.
+
+Precedence is the exception. All 26 packages surveyed carry
+`.claude-plugin/plugin.json` and none carries a root `plugin.json`, so the
+corpus never reaches the second rung of the ladder. Build that fixture by hand
+and mark it synthetic.
+
+- Precedence resolves to Agent Plugins for a package carrying both, reports the
+  other, and records both in `.lola-origin` (synthetic fixture)
+- Precedence is reported even when only one manifest is present
+- A manifest carrying only `name`, `description` and `author` is accepted
+- An unknown top-level field warns, lands in `formats`, and does not fail the
+  parse
+- Round-trip: `import claude → export claude` is parsed-equal, including the
+  `formats` residue
+- An adapter writing outside its own `formats` id fails the test suite
+- Export to a format requiring an absent field fails and names field and target
+- Export of a module with `targets` set reports that `targets` was not carried
+- A content template requesting any capability is refused
+- `mod convert` writes `lola.yml` and leaves every other file in the package
+  untouched
+- Adding a target extension leaves core unchanged
+- Validation runs with no network access
+
+Per-format coverage is published as a generated conformance statement rather
+than asserted in prose: each requirement marked active, skipped or xfail, with
+a written waiver for every skip.


### PR DESCRIPTION
----
> 🦾 Written with LLM assistance [claude-opus-5]
> 💪 Reviewed by a human before submission
----

## Summary

Adds ADR for polyglot format handling and two design docs. Lola adapts any packaging format in,
normalises onto `lola.yml`, and renders back out through target-aware
templates.

This started as Claude Code plugin support for #179. It was raised a level once
the Claude-only draft made the general rule obvious: the fan-out is the
problem, not the Claude gap. The `superpowers` package hand-maintains nine
parallel manifests describing one artifact, as of 6.3.0. Answering #179 per
client costs N×M and puts that same drift inside Lola's own docs. Adapters plus
templates cost N+M: 18 pieces against 72 conversions.

A target extension owns its client's format in both directions, so adding a
tool is one bundle rather than an ADR, a reader, an emitter and a release.
There is no sixth extension kind; ADR-0003's five stand. The acceptance test is
that adding target N+1 leaves core unchanged.

<details>
<summary>What changes in the format itself</summary>

`lola.yml` becomes the intermediate representation and grows to hold it:
`version`, `author`, `license`, `homepage`, `keywords` and `repository`, all
optional. This is not new scope. The design doc already mapped `version`,
`author` and `license` outward as though they existed, while `Module` in the
source defined none of them. The dependency was load-bearing and undeclared.

Nothing is dropped silently on the way in. Vendor-specific residue is preserved
verbatim in a `formats` block keyed by format id, so round-trip fidelity
becomes a test rather than a promise. A publisher can run Lola over an existing
`.claude-plugin/` without losing `category`.

Normalisation happens once, at `mod add`, and is recorded. Precedence and the
scan verdict land in `.lola-origin` instead of being re-derived on every
operation. That also gives ADR-0003's reserved `scan` kind a single place to
hook, and its first concrete justification.

Export is explicit and never a side effect of install: `lola mod export
--target <id>`. `publish` stays reserved for pushing to a catalog or registry.
That is what it means in npm and cargo, and Lola's target list includes OCI
registries.

</details>

<details>
<summary>Why not contribute to APM instead</summary>

APM is Python. The Go migration commits Lola to a binary linking skillimage and
sigstore-go directly, so the runtimes do not meet. Five of APM's design lessons
are borrowed explicitly, and the one not borrowed is named.

</details>

## Dependencies

This ADR references two others that are in flight on their own branches:

| Reference                     | Branch                     | Needed for                        |
|-------------------------------|----------------------------|-----------------------------------|
| #239 Extension Sandboxing | `adr/extension-sandboxing` | confinement for content templates |
| #244 CLI Verb Conventions | `adr/cli-verb-conventions` | why `export` and not `publish`    |

Both are named in plain text rather than linked, so this PR adds no broken link
and can merge in any order. `mkdocs build --strict` on this branch reports the
same two pre-existing `dev-guide/contributing.md` warnings as `main` and no
others. The links become worth adding once those two land.

It also calls the catalog extension kind `marketplace`, which `main` still
names `repo`. That rename is the `docs/marketplace-terminology` PR. The ADR
says so in its own Context section rather than leaving a reader to discover it.

## Related Issues

Relates to #179, Relates to #195, Relates to #232.

## Spec / ADR Reference

ADR: `docs/adr/polyglot-formats.md`
Design: `docs/dev-guide/design/polyglot-formats.md`
Adapter: `docs/dev-guide/design/claude-adapter.md`

## Test Plan

Docs-only, so review is reading rather than running.

<details>
<summary>The load-bearing claims and how to check them</summary>

- [ ] The gap is real: `git grep -l claude-plugin -- docs/` returns nothing on
      `main`. Repo-wide, the only hits are fixture directory names in
      `tests/test_cli_install.py` and `tests/test_cli_sync.py`
- [ ] The metadata gap is real: `Module` in `src/lola/models.py` defines no
      `version`, `author`, `license`, `homepage`, `keywords` or `repository`,
      while the adapter doc maps three of them outward
- [ ] The two formats are siblings rather than nested. Agent Plugins is
      `plugin.json` at a package root, Claude Code is
      `.claude-plugin/plugin.json`. Compare against the Decision section of
      `docs/adr/agent-plugins-format.md`
- [ ] The field frequencies and `source` shape counts in the adapter doc were
      read from installed packages, not from a specification. They are stated
      as observations and the schema URL is given for the authoritative version
- [ ] The nine-manifest example is checkable against `superpowers` 6.3.0, which
      ships `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
      `.agents/plugins/marketplace.json`, `.codex-plugin/`, `.cursor-plugin/`,
      `.devin-plugin/`, `.hermes-plugin/`, `.kimi-plugin/` and
      `gemini-extension.json`
- [ ] Precedence has no natural fixture. All 26 surveyed packages carry
      `.claude-plugin/plugin.json` and none carries a root `plugin.json`, so
      the test suite marks that fixture synthetic
- [ ] APM is Python: `pyproject.toml` and `uv.lock` at the repo root, and
      `install.sh` falls back to `pip` against a Python 3.9 minimum
- [ ] The precedence order puts the most expressive format first, and nothing
      merges
- [ ] Neither design doc invents a vendor extension for fields that do not fit
      a target format
- [ ] Round-trip is specified as semantically identical rather than
      byte-identical, and the reason is given
- [ ] `mkdocs build --strict` reports the same two pre-existing
      `dev-guide/contributing.md` warnings as `main`, and no others

</details>

## Checklist

<details>
<summary>Docs-only, so most items are N/A</summary>

- [x] Tests pass (`pytest` / `go test -race ./...`): N/A, docs only
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`): N/A
- [x] `go vet ./...` passes (Go changes only, N/A otherwise): N/A
- [x] Type checking passes (`uv run ty check`): N/A
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

</details>

## AI Disclosure

AI-assisted with Claude Code. The manifest shapes, field frequencies and
`source` type counts were read from Claude Code plugin packages installed on
the authoring machine rather than from the published schema, and the adapter
doc says so where it matters. APM's language, distribution method and published
conformance practice were read from its repository rather than recalled.
