### PR TITLE
docs(adr): add CLI object model

### DIFF
--- a/docs/adr/cli-object-model.md
+++ b/docs/adr/cli-object-model.md
@@ -1,0 +1,340 @@
+# ADR: CLI Object Model
+
+**Status**: Proposed
+**Date**: 2026-08-26
+**Last Updated**: 2026-08-26
+**Authors**: trevor-vaughan
+**Reviewers**:
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+## Context
+
+Readers of `dev-guide/architecture.md` cannot work out why some operations
+live under `lola mod` and some live at the top level. The reflex is to reach
+for `lola mod install`, which does not exist, and the docs do not explain the
+absence.
+
+[CLI Verb Conventions](cli-verb-conventions.md) settled how operations are
+*spelled*. It explicitly declined to settle what they operate *on*, twice: §4
+routes `remove` but records that "the underlying split is the same one #48
+raises about registry and cache", and §3 leaves `lola update` with "a meaning
+no other manager would predict". This ADR is the record those deferrals point
+at.
+
+### Lola runs three grammars at once
+
+**A — `lola <verb>`, object implied.**
+`install`, `uninstall`, `update`, `list`, `sync`
+
+**B — `lola <noun> <verb>`.**
+`mod add|init|rm|ls|info|update|search`,
+`market add|ls|set|rm|update`
+
+**C — `lola <verb> --<noun>`.**
+`search --mod`, `search --market`
+
+Grammar A works only because the object is silently assumed to be a module.
+`lola mod search` is already a deprecated alias for `lola search --mod`, so one
+command has been migrated from B to C without any written rule saying that is
+the direction of travel.
+
+### What the other managers actually do
+
+Verbs run with `--help` on this box; a command is a noun-first group when
+`<manager> <noun> --help` exits zero and lists subcommands.
+
+| Manager | Implicit primary object | Noun-first groups |
+|---|---|---|
+| dnf | `dnf install foo` | 4 — `group`, `module`, `history`, `mark` |
+| npm | `npm install foo` | 9 — `cache`, `config`, `pkg`, `org`, … |
+| pip | `pip install foo` | 3 — `cache`, `config`, `index` |
+| podman | `podman run` (alias) | canonical — `container`, `image`, … |
+| gh | **none** | all — `pr`, `issue`, `repo`, `alias`, … |
+
+npm's nine are `cache`, `config`, `team`, `org`, `token`, `profile`, `pkg`,
+`owner` and `access`.
+
+Four of five accept an implicit primary object at the top level *and* carry
+noun-first groups for secondary objects. **Lola's A+B mixture is the majority
+pattern, not a defect.** Grammar C is the outlier: no surveyed manager selects
+an object type with a flag.
+
+### What that tier is called elsewhere, and what verbs it takes
+
+| Manager | Name | Verbs it accepts |
+|---|---|---|
+| dnf | not exposed | `clean {metadata,packages,dbcache,expire-cache,all}` |
+| npm | `cache` | `add`, `clean`, `ls`, `verify` |
+| pip | `cache` | `dir`, `info`, `list`, `remove`, `purge` |
+| **lola** | **`mod`** | `add`, `rm`, `ls`, `info`, `update`, `init`, `search` |
+
+Two findings follow, and both are checkable rather than argued:
+
+1. **No manager puts `install` on the cache namespace.** `npm cache add` fills
+   the cache; `npm install` installs. They are different operations with
+   different names. So `lola mod install` is correctly absent — but nothing in
+   the CLI communicates that, because the group is named after the *domain
+   noun* (`mod`) rather than after the *tier* it manages.
+
+2. **"Registry" means the remote, everywhere else.**
+   `npm config get registry` returns `https://registry.npmjs.org/`. Lola's
+   `concepts/what-is-lola.md` labels the *local* directory
+   `~/.lola/modules/` the "GLOBAL REGISTRY", while `dev-guide/architecture.md`
+   calls the same path the "Local Cache". The two docs disagree, and the
+   losing one uses the industry's word for the tier Lola calls a marketplace.
+   `cli-reference/index.md` sits on the losing side too, describing
+   `lola search` as covering "the local registry" and `--mod` as scoping to
+   "the local module registry".
+
+### The tier is only half transparent
+
+`src/lola/cli/install.py` searches enabled marketplaces when a module is not
+found locally, so `lola install <name>` populates the cache by itself. There is
+no equivalent for direct sources: a git URL, archive or folder must go through
+`lola mod add` first, because `install` takes a module name and not a source.
+`architecture.md` shows this as two arrows into the cache but describes it as
+one flow — "added (via `lola mod add` or through a market install)".
+
+That asymmetry is the actual cause of the confusion. A cache you must populate
+by hand for half your sources is not experienced as a cache; it is experienced
+as a second install step, which is exactly what makes `lola mod install` feel
+like it should exist.
+
+## Decision
+
+### 1. The object model is hybrid, and this is the rule
+
+- The **module is the primary object.** Operations on modules are top-level
+  verbs with the object implied: `lola install`, `lola uninstall`, `lola list`.
+- **Every other object gets a noun-first group**: `lola market <verb>`, and the
+  remaining kinds from [Extension Architecture](extension-architecture.md) as
+  they gain commands.
+- **Object type is never selected with a flag.** Grammar C is retired.
+  `lola search --mod` / `--market` become scope arguments on the search itself,
+  and `lola mod search` is un-deprecated as the noun-first form.
+
+A new command answers one question first: does it act on a module, or on
+something else? That determines its position before its name is chosen.
+
+### 2. The three tiers are named source, cache and project
+
+| Tier | Path | Name |
+|---|---|---|
+| Source | git, archive, folder, marketplace | **source** |
+| Machine-global | `~/.lola/modules/` | **cache** |
+| Project | `<project>/.lola/modules/` | **project** |
+
+"Registry" is retired for the local tier. It is the industry's word for the
+remote, and Lola already has a word for the remote. Every source handler in
+`src/lola/parsers.py` copies into the cache directory rather than referencing
+the original, so the tier is derived state in every case and "cache" is
+accurate as well as conventional.
+
+This resolves the registry/cache half of #48. It does not decide
+marketplace-versus-repository, which is a separate question in the same thread.
+
+### 3. The cache tier is made uniformly transparent
+
+`lola install` accepts any source `lola mod add` accepts. Installing from a git
+URL, archive or folder fetches into the cache and then installs, exactly as the
+marketplace path already does.
+
+This is the load-bearing change. Once the cache never has to be populated by
+hand, it is a cache in behaviour and not only in name, and the group managing
+it stops looking like a place where `install` belongs. It also answers #234.
+
+### 4. `lola mod` is renamed to `lola cache`, with `mod` kept forever
+
+Under the CLI Verb Conventions alias regime the rename is additive: both
+spellings work everywhere, permanently, the way `podman run` and
+`podman container run` both work. `lola cache add` makes the tier explicit, and
+nobody types `lola cache install`.
+
+The current group mixes three different objects, so the rename is also a split.
+`lola mod init` writes to `Path.cwd()` — it authors a new module and never
+touches the cache. It moves to `lola init`, matching `npm init` and `cargo new`.
+
+| Today | Acts on | Becomes |
+|---|---|---|
+| `lola mod add\|rm\|ls\|info\|update` | the cache | `lola cache <verb>` |
+| `lola mod init` | the working directory | `lola init` |
+| `lola mod search` | the cache | `lola cache search` |
+
+### 5. Each `update` names its tier
+
+`lola update`, `lola mod update` and `lola market update` are three unrelated
+operations sharing one word. CLI Verb Conventions excluded `update` from
+cross-manager aliasing because the managers disagree about its meaning; Lola
+disagrees with itself three ways, which is worse.
+
+Under §2 each `update` is qualified by the tier it acts on: `lola cache update`
+re-fetches from source, `lola market update` refreshes catalogs. Top-level
+`lola update` regenerates assistant files from the project tier, which is the
+divergence CLI Verb Conventions §3 named and declined to fix. It is renamed to
+`lola render`, and `update` is kept as an alias so nothing breaks.
+
+### 6. Extensions inherit the rule
+
+Extension Architecture defines `target`, `repo`, `runtime`, `source` and
+`scan`, and no command kind, so extensions cannot contribute commands today.
+When they can, each kind is a noun-first group under §1. Fixing the grammar
+before that gate opens is cheaper than reconciling five extension authors'
+conventions after.
+
+The `repo` kind is proposed for renaming to `marketplace` on the
+`docs/marketplace-terminology` branch. Either identifier reads the same way
+under §1, so this section does not depend on which name lands.
+
+## Rationale
+
+- **The hybrid grammar is empirically the norm.** Four of five managers do what
+  Lola does. Rewriting the surface to be uniformly noun-first (`gh`) or
+  uniformly flat would trade a conventional shape for an unconventional one.
+- **The confusion is a naming failure, not a structural one.** `lola mod` is
+  named for the domain noun, so it reads as "everything about modules" and
+  invites `mod install`. `npm cache` and `pip cache` are named for the tier,
+  and nobody reaches for `npm cache install`.
+- **"Registry" is actively wrong, not merely inconsistent.** It names the local
+  tier with the word npm uses for the remote — which is the tier Lola calls a
+  marketplace. Two docs disagreeing is a drift bug; the loser being backwards
+  relative to the industry is an architecture bug.
+- **Half-transparency is what makes the split visible.** Marketplace installs
+  need one command and direct sources need two. Users generalise from whichever
+  they met first, and one of the two groups is always surprised.
+- **The rename is cheap under CLI Verb Conventions.** Aliases make it additive.
+  The cost is documentation choosing one voice, which is a cost that ADR
+  already accepted.
+- **One group holding three objects is the root cause.** `mod init` writing to
+  the working directory while its siblings write to `~/.lola/modules/` is the
+  clearest evidence that `mod` is a bag rather than a namespace.
+
+## Consequences
+
+### Positive Consequences
+
+- The reflex to type `lola mod install` disappears, because `lola cache install`
+  is self-evidently wrong
+- `lola install <git-url>` works, removing the two-step asymmetry and answering
+  #234
+- #48's registry/cache half is settled with evidence rather than preference
+- CLI Verb Conventions §4's deferred model question has an answer, so its
+  `remove` routing rests on a documented model
+- The three-way `update` collision is resolved
+- The Extension Architecture kinds have a grammar to inherit before they need
+  one
+
+### Negative Consequences
+
+- This is the largest user-visible rename proposed so far. Aliases keep every
+  old spelling working, but tutorials, the CLI reference and every issue thread
+  citing `lola mod add` now teach a non-canonical form
+- `lola update` → `lola render` renames the command most users type most often.
+  The alias makes it safe, not invisible
+- Two names for one group is a documentation tax for as long as both are
+  accepted, which under the CLI Verb Conventions rules is forever
+- Making `install` accept sources widens its argument surface, and a mistyped
+  module name that looks like a path now fails differently
+- §5 asserts `lola render` is the better name for regenerating assistant files
+  without surveying render/generate/apply/sync the way §1 surveys grammar. It
+  is the weakest-evidenced decision here
+- The CLI Verb Conventions §2 table lists `lola mod list` and `lola mod info`
+  as canonical. If both ADRs land, that table needs amending
+
+## Alternatives Considered
+
+### Alternative 1: Add `lola mod install` and keep everything else
+
+- Description: Honour the reflex directly by aliasing `lola mod install` to
+  `lola install`.
+- Pros: Smallest possible change; the command people reach for works.
+- Cons: Puts a project-tier operation inside a cache-tier namespace, so the
+  group means two tiers at once. No surveyed manager does this.
+- Reason for rejection: It removes the error message without removing the
+  confusion, and makes the model harder to explain afterwards.
+
+### Alternative 2: Go uniformly noun-first, like `gh`
+
+- Description: `lola mod install`, `lola mod list`, `lola market add`, with no
+  implicit object anywhere.
+- Pros: One rule, no exceptions; the reflex is correct by construction.
+- Cons: One of five surveyed managers works this way, and none of the package
+  managers Lola names as models do. `lola mod install` is longer than every
+  equivalent it competes with.
+- Reason for rejection: Consistency bought by leaving the convention Lola's own
+  analogy invokes.
+
+### Alternative 3: Hide the cache entirely, like dnf
+
+- Description: Delete the group. `lola install <source>` does everything;
+  cache maintenance is `lola clean`.
+- Pros: Simplest surface; matches the DNF analogy `architecture.md` opens with.
+- Cons: Destroys real workflows — pinning, offline install and inspecting what
+  is cached all need the verbs. npm and pip both expose the tier for this
+  reason.
+- Reason for rejection: dnf can hide its cache because nothing else uses it.
+  Lola's tier is shared across projects, so it is a thing users reason about.
+
+### Alternative 4: Rename the tier only, leave the commands alone
+
+- Description: Fix `registry` → `cache` in the docs, keep `lola mod`.
+- Pros: Documentation-only; no CLI change and no alias tax.
+- Cons: Leaves the group named after the domain noun, which is the thing that
+  invites `mod install`. Leaves the half-transparent cache.
+- Reason for rejection: It fixes the contradiction two docs have with each
+  other without fixing what either of them describes.
+
+### Alternative 5: Keep `update` at top level
+
+- Description: Accept the three-way collision and disambiguate in help text.
+- Pros: No rename of the most-typed command.
+- Cons: Help text cannot fix a word meaning three things; the user has to read
+  it at the moment they were confident they did not need to.
+- Reason for deferral: Lower stakes than §1–§4. If §5 is contentious it can be
+  split into its own ADR without weakening the rest.
+
+## Implementation Notes
+
+Ordered so that each step is useful alone and nothing is a prerequisite for a
+decision that has not been made.
+
+1. **Documentation first, no code.** Reconcile `architecture.md`,
+   `what-is-lola.md` and `cli-reference/index.md` on `cache`, relabel the
+   duplicated `lola install` arrow in the `architecture.md` diagram, and state
+   the market-install shortcut explicitly. This is the part that fixes today's
+   confusion, and it is reversible.
+2. **Make `install` accept sources** (§3). Behavioural, additive, and the change
+   that makes the rest read as tidying rather than churn. Check #217 against it
+   first — "install only works the first time" may be a symptom of the same
+   asymmetry.
+3. **Add the `cache` spelling** (§4) with `mod` aliased. Update the CLI
+   reference in the same release or it teaches the wrong canonical form.
+4. **Split `mod init` to `lola init`** (§4).
+5. **Rename `update` to `render`** (§5), last, because it is the weakest-
+   evidenced and the easiest to drop.
+6. **Retire Grammar C** (§1) whenever `search` is next touched.
+
+Depends on CLI Verb Conventions for the alias mechanism: every rename here is
+additive only because that ADR's alias regime exists. If it is rejected, steps
+3–5 are breaking changes and must be reconsidered.
+
+The verb tables in Context were produced on CentOS Stream 10 with dnf 4.20.0,
+npm 11.9.0, pip 23.3.2, podman 6.1.0 and gh 2.97.0.
+
+## References
+
+- Issue #48 — mental model and terminology, including registry versus cache
+- Issue #234 — one-command install
+- Issue #217 — install only works the first time
+- Issue #137 — `list` and `remove` aliases (answered by CLI Verb Conventions)
+- [ADR: Extension Architecture](extension-architecture.md) — the five
+  extension kinds that inherit §1
+- [ADR: CLI Verb Conventions](cli-verb-conventions.md) — verb spellings and the
+  alias regime this ADR depends on; §4 defers the model question answered here
+- [Design: CLI Object Model](../dev-guide/design/cli-object-model.md)
+- [`npm cache`](https://docs.npmjs.com/cli/commands/npm-cache) and
+  [`pip cache`](https://pip.pypa.io/en/stable/cli/pip_cache/) — the two
+  managers whose local tier matches Lola's

--- a/docs/adr/cli-verb-conventions.md
+++ b/docs/adr/cli-verb-conventions.md
@@ -1,0 +1,233 @@
+# ADR: CLI Verb Conventions
+
+**Status**: Proposed
+**Date**: 2026-08-25
+**Last Updated**: 2026-08-26
+**Authors**: trevor-vaughan
+**Reviewers**:
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+## Context
+
+Lola's users arrive from other package managers and type what those managers
+taught them. Issue #137 asks for `list` and `remove` alongside `ls` and `rm`.
+Issue #157 asks for `ls` to be the default under `lola mod`. Both are the same
+request: the command someone already knows should work.
+
+Whether that request is worth honouring can be settled with evidence rather than
+taste. Running each verb with `--help` against dnf 4.20.0, npm 11.9.0,
+pip 23.3.2, cargo 1.96.1 and gem 3.6.9:
+
+|       | `install` | `uninstall` | `remove` | `rm` | `erase` | `add` |
+|-------|-----------|-------------|----------|------|---------|-------|
+| dnf   | yes       | **no**      | yes      | yes  | yes     | no    |
+| npm   | yes       | yes         | yes      | yes  | no      | yes   |
+| pip   | yes       | yes         | **no**   | no   | no      | no    |
+| cargo | yes       | yes         | yes      | yes  | no      | yes   |
+| gem   | yes       | yes         | **no**   | no   | no      | no    |
+
+|       | `list` | `ls` | `info` | `show` | `search` | `update` | `upgrade` |
+|-------|--------|------|--------|--------|----------|----------|-----------|
+| dnf   | yes    | yes  | yes    | no     | yes      | yes      | yes       |
+| npm   | yes    | yes  | yes    | yes    | yes      | yes      | yes       |
+| pip   | yes    | no   | **no** | yes    | yes      | no       | no        |
+| cargo | **no** | no   | yes    | no     | yes      | yes      | no        |
+| gem   | yes    | no   | yes    | no     | yes      | yes      | no        |
+
+`install` and `search` are the only verbs all five agree on. Every other
+operation is spelled differently depending on where the user came from, so any
+single choice is wrong for a large share of them.
+
+Lola sits on that fault line. It uses `uninstall`, which is the one removal verb
+dnf does not have, while `dev-guide/architecture.md` opens by comparing Lola to
+DNF.
+
+The spellings also disagree inside Lola. `lola market ls` and `lola mod ls` use
+the short form; `lola list` uses the long one. Same operation, two spellings,
+depending on depth.
+
+## Decision
+
+### 1. The command set stays small; the accepted names do not
+
+Surface is managed by keeping few *operations*, not few *names*. An alias adds a
+spelling, not a concept, and costs the reader nothing because they never see the
+ones they did not type. npm accepts six spellings across two operations and is
+not considered confusing for it.
+
+Where the number of commands does grow, it is managed with Cobra command groups
+rather than by refusing useful commands.
+
+### 2. Canonical names follow the evidence
+
+Where managers disagree, the canonical name is the one with the widest support
+in the table above, and the others become aliases:
+
+| Operation | Canonical   | Aliases                                  |
+|-----------|-------------|------------------------------------------|
+| Install   | `install`   | `add`                                    |
+| Remove    | `uninstall` | `remove`, `rm`, `erase`, `delete`, `del` |
+| List      | `list`      | `ls`                                     |
+| Describe  | `info`      | `show`, `view`                           |
+| Search    | `search`    | `find`                                   |
+
+`list` beats `ls` four managers to two, and `info` beats `show` four to two, so
+Lola's top-level `lola list` is right and `lola market ls` / `lola mod ls` are
+the ones that move. Both spellings keep working everywhere.
+
+### 3. `update` is excluded from cross-manager aliasing
+
+It is the one verb where the managers actively disagree on meaning rather than
+spelling. In dnf, `update` and `upgrade` are the same command. In apt they are
+not: one refreshes the index, the other installs. Aliasing across that
+disagreement makes Lola's behaviour depend on which manager the user learned,
+which is the opposite of the goal.
+
+So `update` and `upgrade` are not aliased to each other, and neither is aliased
+to anything else. Each `update` in Lola documents precisely what it updates.
+
+This leaves a known divergence rather than fixing it: `lola update` regenerates
+assistant files, which resembles nothing in the other five managers. Renaming it
+is out of scope here and worth its own decision.
+
+### 4. Ambiguous verbs are answered, not guessed
+
+Lola has two removal concepts where dnf has one: a module can leave a project
+(`lola uninstall`) or leave the local registry (`lola mod rm`).
+
+`remove` and its aliases map to `uninstall`, because in every manager surveyed
+"remove" means removing from the thing you are operating on, and for Lola that
+is the project. The registry is closer to a cache, which no manager empties with
+`remove`.
+
+When the module remains in the registry afterwards, Lola says so and names the
+command that would remove it there. Where an invocation is genuinely ambiguous,
+the error names both options rather than picking one silently.
+
+### 5. Aliases must be discoverable
+
+Cobra registers aliases but does not complete them, and does not show them in
+help. Both gaps are closed: shell completion offers aliases alongside canonical
+names, and help lists them. An alias a user cannot discover only helps the user
+who already guessed it.
+
+### 6. User aliases are configurable, in addition to the defaults
+
+Lola gains `lola alias set|list|delete|import`, modelled on `gh`. Two rules:
+
+- **A user alias cannot shadow a built-in command.** Otherwise `lola install`
+  means different things on different machines and no bug report reproduces.
+- **The conventional verbs in §2 live in the binary, not in seeded
+  configuration.** A user who clears their config keeps `remove`. The config is
+  additive only.
+
+## Rationale
+
+- **The question is empirical.** Five managers, one agreed removal verb between
+  them: none. Any single spelling is wrong for a large share of users, so this
+  is not a matter of preference.
+- **Lola's own analogy picks the losing verb.** The architecture doc leads with
+  DNF, and dnf is the one manager without `uninstall`.
+- **Aliases are read-cheap.** A user never sees the spellings they did not type.
+  The cost lands on maintainers, in help text and completion, and both are
+  mechanical.
+- **Spelling and meaning are different problems.** Aliasing is safe where
+  vocabularies differ and dangerous where they collide. `update` is the only
+  verb in the table that collides.
+- **Two removal concepts is a model question, not a CLI question.** The CLI can
+  route the common case and name the other, but the underlying split is the same
+  one #48 raises about registry and cache.
+
+## Consequences
+
+### Positive Consequences
+
+- Someone arriving from dnf, apt, npm, pip, cargo or gem can type their own
+  removal verb and have it work
+- `lola list` and `lola mod list` stop disagreeing about the same operation
+- #137 and #157 are both answered by one rule rather than two patches
+- Aliases become discoverable through completion and help, which is what makes
+  them worth having
+
+### Negative Consequences
+
+- Every accepted alias is API. Removing `del` later breaks whoever used it, so
+  the set should be argued once rather than grown casually
+- Five spellings of one operation makes documentation choose a voice; docs
+  should use canonical names throughout or they teach the aliases by accident
+- `lola update` keeps a meaning no other manager would predict, and this ADR
+  names that without fixing it
+- A user alias system is a support surface: bug reports need to say whether an
+  alias was involved
+- Completion output grows, and a long completion list is its own kind of noise
+
+## Alternatives Considered
+
+### Alternative 1: Pick one spelling and document it
+
+- Description: Choose `uninstall`, document it, decline aliases.
+- Pros: Smallest surface; one name in docs, help and errors.
+- Cons: The table shows no spelling covers the audience. Documentation does not
+  help someone who typed the wrong verb and got "unknown command".
+- Reason for rejection: It answers #137 with "read the manual", which is what
+  the issue is about.
+
+### Alternative 2: Ship the aliases as default configuration
+
+- Description: Seed the conventional verbs into the user config at first run.
+- Pros: One mechanism instead of two; users can edit the defaults.
+- Cons: Behaviour becomes dependent on config state, so a cleared config removes
+  verbs the documentation promises, and support cannot assume a baseline.
+- Reason for rejection: Defaults that live in mutable state are not defaults.
+
+### Alternative 3: Alias `update` and `upgrade` to each other
+
+- Description: Accept both spellings, as dnf does.
+- Pros: Matches dnf and npm; one less thing to remember.
+- Cons: apt users mean "refresh the index" by `update`, and Lola would do
+  something else. The failure is silent and lands on the user's project.
+- Reason for rejection: The two words disagree about meaning, not spelling.
+
+### Alternative 4: Make `remove` an error that names both options
+
+- Description: Refuse to route `remove`, and print the two candidates.
+- Pros: Never does the wrong thing; teaches the model.
+- Cons: The common case has an obvious answer, and an error for the common case
+  is not "just works".
+- Reason for deferral: Kept for genuinely ambiguous invocations, not for
+  `remove` itself.
+
+## Implementation Notes
+
+Aliases first, since they are self-contained and answer the open issues.
+
+1. Add the §2 alias sets with Cobra `Aliases`, plus completion and help support.
+   This is where #137 and #157 close.
+2. Reconcile `ls` and `list` across `lola`, `lola market` and `lola mod`, with
+   both spellings accepted at every level.
+3. Add command groups once the surface justifies it.
+4. Add `lola alias` last. It is the only part that needs new configuration, and
+   the defaults must ship before a user alias system can be described as
+   additive.
+
+Step 2 changes documented command names. The old spellings keep working, so the
+change is additive, but the CLI reference and any tutorial content need updating
+in the same release or they teach the wrong canonical form.
+
+`lola mod search` is already documented as a deprecated alias for `lola search
+--mod`, so a precedent exists for retiring a spelling without breaking it.
+
+## References
+
+- Issue #137 — `list` and `remove` as alternatives for `ls` and `rm`
+- Issue #157 — make `ls` the default for `lola mod`
+- Issue #56 — LLM-friendly `--help`
+- Issue #48 — mental model and terminology, including registry versus cache
+- [ADR: Extension Architecture](extension-architecture.md) — extensions
+  contribute commands, so the alias rule has to reach them
+- [`gh alias`](https://cli.github.com/manual/gh_alias) — the user alias model,
+  including `import` from YAML

--- a/docs/dev-guide/design/cli-object-model.md
+++ b/docs/dev-guide/design/cli-object-model.md
@@ -1,0 +1,153 @@
+# CLI Object Model
+
+----
+> 🦾 Written with LLM assistance [claude-opus-5]
+> 💪 Reviewed by a human before submission
+----
+
+Implementation design for
+[ADR: CLI Object Model](../../adr/cli-object-model.md). The ADR argues which
+object each command acts on; this document is the resulting command map, the
+migration, and how to check it.
+
+Read [CLI Verb Conventions](cli-verb-conventions.md) and its
+[ADR](../../adr/cli-verb-conventions.md) first. Every rename below is additive
+only because that alias regime exists.
+
+## Placement rule
+
+One question decides where a command goes:
+
+```text
+Does it act on a module?
+├── yes, in the project  → top level, object implied   lola install
+├── yes, in the cache    → lola cache <verb>           lola cache add
+├── yes, on disk here    → top level, authoring verb   lola init
+└── no                   → lola <noun> <verb>          lola market add
+```
+
+Object type is never a flag. `--mod` and `--market` on `lola search` are the
+only violations and they are retired.
+
+## Command map
+
+Canonical on the left, and every listed alias keeps working permanently.
+
+| Operation | Canonical | Aliases | Acts on |
+|---|---|---|---|
+| Install into project | `lola install` | `add` | project |
+| Remove from project | `lola uninstall` | Verb Conventions ADR §2 set | project |
+| List installed | `lola list` | `ls` | project |
+| Regenerate assistant files | `lola render` | `update` | project |
+| Apply `.lola-req` | `lola sync` | — | project |
+| Author a new module | `lola init` | `mod init` | working directory |
+| Fetch into cache | `lola cache add` | `mod add` | cache |
+| Drop from cache | `lola cache rm` | `mod rm`, `cache remove` | cache |
+| List cached | `lola cache list` | `mod ls`, `cache ls` | cache |
+| Describe cached | `lola cache info` | `mod info`, `cache show` | cache |
+| Re-fetch from source | `lola cache update` | `mod update` | cache |
+| Search | `lola search` | `find` | all tiers |
+| Search the cache | `lola cache search` | `mod search` | cache |
+| Register a marketplace | `lola market add` | — | marketplace |
+| Drop a marketplace | `lola market rm` | Verb Conventions ADR §2 set | marketplace |
+| List marketplaces | `lola market list` | `ls` | marketplace |
+| Enable/disable | `lola market set` | — | marketplace |
+| Refresh catalogs | `lola market update` | — | marketplace |
+
+Three groups exist: top level (module, implied), `cache`, and `market`.
+The remaining kinds from
+[Extension Architecture](../../adr/extension-architecture.md) — `target`,
+`runtime`, `source`, `scan` — become groups on the same pattern if they gain
+commands.
+
+## `install` accepts sources
+
+Today `install` takes a module name and searches marketplaces when it misses
+the cache (`src/lola/cli/install.py`). Direct sources have no such path, so a
+git URL needs `lola mod add` first. That asymmetry is what the ADR's §3
+removes.
+
+Resolution order for `lola install <arg>`:
+
+1. `@marketplace/module` — explicit marketplace, unchanged
+2. Present in the cache — install from cache, unchanged
+3. Parses as a source that a `SOURCE_HANDLER` accepts — fetch into the cache,
+   then install
+4. Found in exactly one enabled marketplace — fetch, then install, unchanged
+5. Found in several — prompt, unchanged
+6. Otherwise — error naming both what was searched and the source forms
+   accepted
+
+Step 3 is the new one and it must come *after* the cache check, so that a
+cached module named like a path still resolves to the cached copy. It reuses
+`parsers.SOURCE_HANDLERS` rather than re-implementing detection; whatever
+`lola cache add` accepts, `lola install` accepts, with no second list to drift.
+
+A source that fetches but fails to install leaves the module cached. That is
+the same end state as `lola cache add` and is worth saying in the error,
+because the retry is then `lola install <name>` and not the URL again.
+
+Check #217 ("install only works the first time") against step 2 before
+building step 3. If it is a cache-hit bug, it lives in the code path this
+change reorders.
+
+## Renaming without breaking
+
+`mod` and `update` are the two spellings in the wild. Both survive as aliases,
+so the migration is documentation and defaults rather than behaviour.
+
+| Concern | Handling |
+|---|---|
+| Existing scripts | Aliases resolve identically, no warning on the alias path |
+| `.lola-req` files | Unaffected — a declarative file, no verbs |
+| Shell completion | Offers canonical names; aliases complete but rank below |
+| `--help` | Lists every accepted spelling, per Verb Conventions ADR §5 |
+| Docs and tutorials | Must switch to canonical names in the same release |
+
+`lola mod search` is currently documented as deprecated in favour of
+`lola search --mod`. That deprecation reverses: `--mod` is the Grammar C
+violation, so `lola cache search` becomes canonical and `mod search` becomes a
+plain alias rather than a deprecated one.
+
+## Tier vocabulary
+
+One word per tier, in code, docs and error messages:
+
+| Tier | Path | Word | Never |
+|---|---|---|---|
+| Source | git, archive, folder, marketplace | source | origin, upstream |
+| Machine-global | `~/.lola/modules/` | cache | registry, store, global |
+| Project | `<project>/.lola/modules/` | project | local, workspace |
+
+"Registry" is retired for the local tier: `npm config get registry` returns
+`https://registry.npmjs.org/`, so the word means the remote everywhere else,
+and Lola's remote is a marketplace.
+
+Two files disagree today and both change:
+
+- `docs/dev-guide/architecture.md` — "Local Cache" (keep, drop "Local")
+- `docs/concepts/what-is-lola.md` — "GLOBAL REGISTRY" (change to "CACHE")
+
+`architecture.md`'s diagram also labels two different arrows `lola install`
+(markets → cache, and cache → project). Under the ADR's §3 the first is no
+longer a separate user action, so that arrow becomes unlabelled or is folded
+into the source node.
+
+## Verification
+
+- `lola cache add <git-url>` and `lola mod add <git-url>` produce identical
+  state
+- `lola install <git-url>` on an empty cache leaves the module both cached and
+  installed
+- `lola install <name>` with `<name>` cached does not hit the network, even if
+  a file of that name exists in the working directory
+- `lola install ./does-not-exist` errors naming both the marketplaces searched
+  and the accepted source forms
+- `lola render` and `lola update` produce identical state
+- `lola init` and `lola mod init` both scaffold into the working directory
+- `lola cache bogsu` exits non-zero rather than listing, per
+  [CLI Verb Conventions](cli-verb-conventions.md)
+- `--help` for every renamed command lists the old spelling
+- No occurrence of "registry" referring to `~/.lola/modules/` remains in
+  `docs/` or in user-facing strings under `src/`
+- `mkdocs build` succeeds

--- a/docs/dev-guide/design/cli-verb-conventions.md
+++ b/docs/dev-guide/design/cli-verb-conventions.md
@@ -5,9 +5,10 @@
 > 💪 Reviewed by a human before submission
 ----
 
-Implementation detail for [ADR-0010](../../adr/0010-cli-verb-conventions.md).
-The ADR owns the rule; this document owns the command map, the two Cobra gaps
-that have to be closed by hand, and the alias configuration format.
+Implementation detail for
+[ADR: CLI Verb Conventions](../../adr/cli-verb-conventions.md). The ADR owns
+the rule; this document owns the command map, the two Cobra gaps that have to
+be closed by hand, and the alias configuration format.
 
 The support figures quoted here were produced by running each verb with `--help`
 against dnf 4.20.0, npm 11.9.0, pip 23.3.2, cargo 1.96.1 and gem 3.6.9, and by
@@ -148,8 +149,9 @@ user alias, because chains make an unknown-command error impossible to explain.
 
 ## Extensions
 
-ADR-0003 defines five extension kinds — `target`, `repo`, `runtime`, `source`
-and `scan` — and none of them contributes a CLI command. Extensions cannot add
+[ADR: Extension Architecture](../../adr/extension-architecture.md) defines five
+extension kinds — `target`, `repo`, `runtime`, `source` and `scan` — and none
+of them contributes a CLI command. Extensions cannot add
 verbs today, so nothing here applies to them yet.
 
 Recording one rule now, because it is cheaper than retrofitting it: if a future


### PR DESCRIPTION
----
> 🦾 Written with LLM assistance [claude-opus-5]
> 💪 Reviewed by a human before submission
----

## Summary

Adds a CLI object model ADR and its design doc: which object each command acts on, the three
tier names, and a cache that is transparent in every case rather than half the
time.

#244 settled how operations are *spelled*. It twice declined to settle what
they act *on*: §4 sent the registry/cache split to #48, and §3 left `lola
update` with "a meaning no other manager would predict". This is the record it
defers to.

Three findings drive it.

1. The reported confusion reproduces. Readers of `dev-guide/architecture.md`
   cannot work out why some operations sit under `lola mod` and others at the
   top level, so they reach for `lola mod install`, which does not exist.
2. The structure itself is fine. Four of five surveyed managers accept an
   implicit primary object at the top level *and* carry noun-first groups for
   secondary objects. `npm cache add|clean|ls|verify` and `pip cache
   dir|info|list|remove|purge` are the same shape as `lola mod add|rm|ls|info`.
   So this is not a proposal to remove the split.
3. Two things the survey does condemn. No manager puts `install` on the cache
   namespace; `npm cache add` is not `npm install`. And `npm config get
   registry` returns `https://registry.npmjs.org/`, so "registry" means the
   *remote* everywhere else.

The load-bearing change is §3, making `install` accept any source that `mod
add` accepts. Today `src/lola/cli/install.py` searches marketplaces on a cache
miss, but a git URL has no such path and must go through `lola mod add` first.
Half of users meet a one-step install and half a two-step one, so one group is
always surprised. Once that lands, §4's rename is tidying.

<details>
<summary>Why the naming is actively wrong</summary>

`concepts/what-is-lola.md` labels the local `~/.lola/modules/` the "GLOBAL
REGISTRY", while `dev-guide/architecture.md` calls the same path the "Local
Cache". The two docs disagree, and the losing one uses the industry's word for
the tier Lola calls a marketplace. `cli-reference/index.md` sits on the losing
side too, describing `lola search` as covering "the local registry". That
settles the registry/cache half of #48 with one command's output rather than a
preference.

`lola mod` also holds three different objects. `mod add|rm|ls|info|update` act
on `~/.lola/modules/`. `mod init` writes to `Path.cwd()` and never touches the
cache. `mod search` is a deprecated alias. Named for the domain noun rather
than the tier, the group reads as "everything about modules", which is exactly
the reflex being reported.

</details>

## Related Issues

Relates to #48, Relates to #234, Relates to #217, Relates to #137.

## Spec / ADR Reference

ADR: `docs/adr/0011-cli-object-model.md`
Design: `docs/dev-guide/design/cli-object-model.md`

## Dependency

Based on `adr/cli-verb-conventions`, not `main`. Every rename here is additive
only because #244's alias regime exists, and the ADR says so in
Implementation Notes. Review that one first; the diff here is two new files.

One known conflict is flagged in Negative Consequences rather than patched.
#244 §2's table lists `lola mod list` and `lola mod info` as canonical, and
§4 here moves them to `lola cache`. If both land, that table needs amending. I
have left it to ADR-0010's reviewer rather than editing it from this branch.

## Test Plan

Docs-only, and the survey is reproducible, which is the point.

<details>
<summary>Commands behind each claim</summary>

- [ ] `npm cache --help` lists `add|clean|ls|verify`, plus `npx ls` on npm 11.
      `pip cache --help` lists `dir|info|list|remove|purge`. Both expose the
      tier as a noun-first group, with different verbs on it.
      `dnf clean --help` exposes maintenance only
- [ ] Neither puts `install` on the cache. `npm cache install` exits `EUSAGE`.
      Run the command itself rather than `--help` on it, which only prints the
      group's usage
- [ ] `npm config get registry` returns `https://registry.npmjs.org/`, which is
      the whole argument for retiring "registry" for the local tier
- [ ] `dnf group --help`, `npm cache --help`, `pip config --help` and
      `podman container --help` all exit zero and list subcommands. `gh` has no
      implicit primary object
- [ ] `podman run` and `podman container run` both work. That is the precedent
      for keeping `mod` forever after renaming to `cache`
- [ ] `src/lola/parsers.py`: every handler `copytree`s into the destination, so
      the cache is derived state in every case and "cache" is accurate
- [ ] `src/lola/cli/mod.py`: `mod init` resolves `Path.cwd()`, not `LOLA_HOME`
- [ ] `src/lola/cli/install.py` searches marketplaces on a cache miss and has no
      equivalent path for direct sources
- [ ] `mkdocs build --strict` matches the baseline below

</details>

<details>
<summary>mkdocs output, run not asserted</summary>

`mkdocs build --strict` on this branch reports two warnings, both pre-existing.
This branch adds none.

```text
WARNING - Doc file 'dev-guide/contributing.md' contains a link
          '../../GOVERNANCE.md', but the target '../GOVERNANCE.md' is not
          found among documentation files.
WARNING - Doc file 'dev-guide/contributing.md' contains a link
          '../../docs/SECURITY.md', but the target '../docs/SECURITY.md' is
          not found among documentation files.
```

Confirmed by building with the two new files removed and again with them
present: two warnings both times. Those broken links are a real docs bug in
`dev-guide/contributing.md`, out of scope here and left untouched.

Reproducing it needs `mkdocs`, `mkdocs-material`,
`mkdocs-awesome-pages-plugin`, `mkdocs-mermaid2-plugin` and
`mkdocs-panzoom-plugin`.

</details>

## Checklist

<details>
<summary>Docs-only, so most items are N/A</summary>

- [x] Tests pass (`pytest` / `go test -race ./...`): N/A, docs only
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`): N/A
- [x] `go vet ./...` passes (Go changes only, N/A otherwise): N/A
- [x] Type checking passes (`uv run ty check`): N/A
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

</details>

## AI Disclosure

AI-assisted with Claude Code. Every table in the ADR came from running the named
command on a CentOS Stream 10 box rather than from training, and the versions
surveyed are stated in Implementation Notes. `mkdocs build --strict` was
actually executed, and its output is quoted above verbatim.

One limit is worth stating. §5's choice of `render` over generate, apply or
sync is the only decision here not backed by a survey. It is flagged as the
weakest-evidenced item in Negative Consequences.
