### PR TITLE
feat: add --plugin flag for native plugin installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ lola install <module> -a claude-code
 
 | Assistant | Skills | Commands | Agents | Plugin |
 |-----------|--------|----------|--------|--------|
-| claude-code | `.claude/skills/` | `.claude/commands/` | `.claude/agents/` | `.claude/skills/<name>/` (project + user) |
+| claude-code | `.claude/skills/` | `.claude/commands/` | `.claude/agents/` | `.claude/skills/<name>/` (project), `~/.claude/skills/<name>/` (user) |
 | cursor | `.cursor/skills/` | `.cursor/commands/` | `.cursor/agents/` | `~/.cursor/plugins/local/<name>/` (user only) |
 | gemini-cli | `GEMINI.md` | `.gemini/commands/` | N/A | N/A |
 | opencode | `AGENTS.md` | `.opencode/commands/` | `.opencode/agents/` | N/A |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ lola install <module> -a claude-code
 | Architecture overview | `docs/dev-guide/architecture.md` |
 | E2E tests | `docs/dev-guide/design/e2e-bdd.md` |
 | CLI reference | `docs/cli-reference/` |
+| Plugin installation | `docs/guides/plugins.md` |
 | Proposing a change | `openspec/changes/` or `specs/` |
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` |
 
@@ -90,14 +91,14 @@ lola install <module> -a claude-code
 
 ### Target Assistants
 
-| Assistant | Skills | Commands | Agents |
-|-----------|--------|----------|--------|
-| claude-code | `.claude/skills/` | `.claude/commands/` | `.claude/agents/` |
-| cursor | `.cursor/skills/` | `.cursor/commands/` | `.cursor/agents/` |
-| gemini-cli | `GEMINI.md` | `.gemini/commands/` | N/A |
-| opencode | `AGENTS.md` | `.opencode/commands/` | `.opencode/agents/` |
-| copilot-cli | `.github/skills/` | `.github/prompts/` | `.github/agents/` |
-| copilot-vscode | `.github/skills/` | `.github/prompts/` | `.github/agents/` |
+| Assistant | Skills | Commands | Agents | Plugin |
+|-----------|--------|----------|--------|--------|
+| claude-code | `.claude/skills/` | `.claude/commands/` | `.claude/agents/` | `.claude/skills/<name>/` (project + user) |
+| cursor | `.cursor/skills/` | `.cursor/commands/` | `.cursor/agents/` | `~/.cursor/plugins/local/<name>/` (user only) |
+| gemini-cli | `GEMINI.md` | `.gemini/commands/` | N/A | N/A |
+| opencode | `AGENTS.md` | `.opencode/commands/` | `.opencode/agents/` | N/A |
+| copilot-cli | `.github/skills/` | `.github/prompts/` | `.github/agents/` | N/A |
+| copilot-vscode | `.github/skills/` | `.github/prompts/` | `.github/agents/` | N/A |
 
 ### Module Structure
 

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -44,7 +44,9 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 | `lola install @<marketplace>/<module>`              | Install from a specific marketplace           |
 | `lola install @<marketplace>/<module>@<ref>`        | Install from a marketplace at a specific ref  |
 | `lola install <module> --append-context <path>`     | Append context reference                      |
+| `lola install <module> --plugin`                    | Install as a self-contained plugin bundle (uses existing `plugin.json` or generates one) |
 | `lola uninstall <module>`                           | Uninstall module                              |
+| `lola uninstall <module> --plugin`                  | Uninstall a plugin bundle                     |
 | `lola list`                                         | List all installations (shows version and ref when set) |
 | `lola update`                                       | Regenerate assistant files                    |
 | `lola sync`                                         | Install modules from `.lola-req`              |

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,0 +1,129 @@
+# Plugin Installation
+
+Lola can install modules as native plugins using the `--plugin` flag. Instead
+of installing skills, agents, commands, and MCPs as individual files scattered
+across assistant-specific directories, `--plugin` bundles everything into a
+single self-contained plugin directory with a `plugin.json` manifest.
+
+## When to Use `--plugin`
+
+Use `--plugin` when the target assistant supports plugins and you want all
+module components to be managed as a single unit. This makes it easier to
+install, update, and remove the module as a whole — and allows the assistant
+to recognize it as a plugin rather than loose files.
+
+## Existing `plugin.json`
+
+If the module already includes a `plugin.json` file, Lola uses it as-is during
+plugin installation. This preserves any metadata the pack author has set (name,
+version, description, extensions, etc.).
+
+If no `plugin.json` is present, Lola generates a manifest based on the target
+implementation per the [Open Plugin Spec](https://agent-plugins.org/).
+
+## Supported Clients
+
+| Client | Project-level | User-level | Notes |
+|--------|:---:|:---:|-------|
+| Claude Code | Yes | Yes | Uses Claude's own `.claude-plugin/` format |
+| Cursor | No | Yes | Uses the [Agent Plugins](https://agent-plugins.org/) global spec |
+| Copilot CLI | — | — | Not yet supported |
+| Copilot VS Code | — | — | Not yet supported |
+| OpenCode | — | — | Does not support plugins |
+| Gemini CLI | — | — | Shut down; replaced by Antigravity (not yet supported by Lola) |
+| OpenClaw | — | — | Not yet supported |
+
+### Claude Code
+
+Claude Code supports plugins at both project and user scope. Plugins are placed
+inside the `.claude/skills/` directory — Claude Code treats any folder under
+`skills/` that contains a `.claude-plugin/plugin.json` as a plugin (not a plain
+skill). This is Claude Code's own format, not the global Agent Plugins spec.
+Claude Code does not support the global spec's `plugin.json` at root for
+skills-directory plugins.
+
+```bash
+# Project-level (default)
+lola install my-module --plugin -a claude-code
+
+# User-level
+lola install my-module --plugin -a claude-code -s user
+```
+
+### Cursor
+
+Cursor supports user-level plugins only — there is no documented project-level
+plugin auto-discovery path. Cursor supports both its own plugin format
+(`.cursor-plugin/plugin.json`) and the [Agent Plugins](https://agent-plugins.org/)
+open standard. Lola uses the global spec format for portability.
+
+```bash
+lola install my-module --plugin -a cursor -s user
+```
+
+### Copilot (CLI and VS Code)
+
+Copilot does not have a drop-in directory for plugins. The
+`~/.copilot/installed-plugins/` directory is managed by Copilot's own
+`copilot plugin install` command and is not intended for external tools.
+Available alternatives:
+
+- **Copilot CLI**: `copilot plugin install /path/to/plugin`
+- **Copilot VS Code**: `chat.pluginLocations` setting in `.vscode/settings.json`
+- **Local marketplace**: `copilot marketplace add /local/path`
+
+Lola does not currently support `--plugin` for Copilot targets.
+
+### OpenCode
+
+OpenCode's "plugins" are JS/TS code modules for TUI/runtime extensions (event
+hooks, custom tools). They do not bundle skills, agents, or MCP configs. Lola
+does not support `--plugin` for OpenCode.
+
+## Uninstalling Plugins
+
+Use `--plugin` when uninstalling a module that was installed as a plugin:
+
+```bash
+lola uninstall my-module --plugin -a claude-code
+```
+
+Lola tracks whether a module was installed as a plugin or as individual files.
+Attempting to uninstall a plugin without `--plugin` (or vice versa) will show
+an error:
+
+```
+my-module was installed as a plugin for claude-code, use --plugin to uninstall
+```
+
+## Error Handling
+
+When using `--plugin` with an unsupported client or scope:
+
+- **Explicit `-a`**: exits with an error message (`--plugin is not supported
+  with opencode` or `project-level plugin is not supported for cursor`)
+- **All-agents mode** (no `-a`): unsupported clients are skipped silently,
+  supported ones are installed as plugins
+
+## Troubleshooting
+
+### Claude Code plugin shows as "(suppressed)"
+
+Claude Code project-level plugins require workspace trust. The trust dialog
+should appear when you open a project with a plugin, but a
+[known bug](https://github.com/anthropics/claude-code/issues/72896) prevents
+it: if any parent directory was previously trusted, Claude Code skips the dialog
+for child directories. But trust is only applied on exact path match, so the
+plugin is blocked with no interactive way to fix it.
+
+To work around this, manually set trust and restart Claude Code:
+
+```bash
+# Check current trust status
+jq --arg p "$(pwd)" '.projects[$p].hasTrustDialogAccepted' ~/.claude.json
+
+# Set trust
+tmp=$(mktemp) && jq --arg p "$(pwd)" \
+  '.projects[$p].hasTrustDialogAccepted = true' \
+  ~/.claude.json > "$tmp" && mv "$tmp" ~/.claude.json
+```

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -29,8 +29,8 @@ implementation per the [Open Plugin Spec](https://agent-plugins.org/).
 | Cursor | No | Yes | Uses the [Agent Plugins](https://agent-plugins.org/) global spec |
 | Copilot CLI | — | — | Not yet supported |
 | Copilot VS Code | — | — | Not yet supported |
-| OpenCode | — | — | Does not support plugins |
-| Gemini CLI | — | — | Shut down; replaced by Antigravity (not yet supported by Lola) |
+| OpenCode | — | — | Does not support Lola plugin bundles |
+| Gemini CLI | — | — | Not yet supported |
 | OpenClaw | — | — | Not yet supported |
 
 ### Claude Code
@@ -92,7 +92,7 @@ Lola tracks whether a module was installed as a plugin or as individual files.
 Attempting to uninstall a plugin without `--plugin` (or vice versa) will show
 an error:
 
-```
+```text
 my-module was installed as a plugin for claude-code, use --plugin to uninstall
 ```
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1060,7 +1060,9 @@ def install_cmd(
     console.print()
     if total_installed > 0:
         console.print(
-            f"[green]Installed to {len(assistants_to_install)} assistant{'s' if len(assistants_to_install) != 1 else ''}[/green]"
+            f"[green]Installed to {total_installed}"
+            f" assistant{'s' if total_installed != 1 else ''}"
+            f"[/green]"
         )
     else:
         console.print("[yellow]Nothing was installed[/yellow]")
@@ -1247,6 +1249,7 @@ def uninstall_cmd(
 
     # Uninstall each
     removed_count = 0
+    uninstalled_count = 0
     for inst in installations:
         target = get_target(inst.assistant)
 
@@ -1297,6 +1300,7 @@ def uninstall_cmd(
                 scope=inst.scope,
                 project_path=inst.project_path,
             )
+            uninstalled_count += 1
             continue
 
         # Remove skill files
@@ -1400,10 +1404,13 @@ def uninstall_cmd(
             scope=inst.scope,
             project_path=inst.project_path,
         )
+        uninstalled_count += 1
 
     console.print(
-        f"[green]Uninstalled from {removed_count} installation{'s' if removed_count != 1 else ''}[/green]"
-        if removed_count > 0
+        f"[green]Uninstalled from {uninstalled_count}"
+        f" installation{'s' if uninstalled_count != 1 else ''}"
+        f"[/green]"
+        if uninstalled_count > 0
         else "[yellow]Nothing was uninstalled[/yellow]"
     )
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1091,6 +1091,13 @@ def install_cmd(
     default=None,
     help="Filter by installation scope",
 )
+@click.option(
+    "--plugin",
+    "as_plugin",
+    is_flag=True,
+    default=False,
+    help="Uninstall a plugin bundle instead of individual files",
+)
 def uninstall_cmd(
     module_name: Optional[str],
     assistant: Optional[str],
@@ -1098,6 +1105,7 @@ def uninstall_cmd(
     project_path: Optional[str],
     force: bool,
     scope: Optional[str],
+    as_plugin: bool,
 ):
     """
     Uninstall a module's skills from AI assistants.
@@ -1243,6 +1251,51 @@ def uninstall_cmd(
         path_context = inst.project_path or ""
         inst_scope = inst.scope
 
+        if as_plugin and not inst.is_plugin:
+            console.print(
+                f"[red]{module_name} was not installed as a plugin"
+                f" for {inst.assistant}[/red]",
+            )
+            continue
+        if not as_plugin and inst.is_plugin:
+            console.print(
+                f"[red]{module_name} was installed as a plugin"
+                f" for {inst.assistant}, use --plugin to"
+                f" uninstall[/red]",
+            )
+            continue
+
+        if as_plugin:
+            layout = target.get_plugin_layout(inst_scope)
+            if layout is None:
+                console.print(
+                    f"[red]--plugin is not supported with {inst.assistant}[/red]",
+                )
+                continue
+            plugin_root = layout.resolve_root(
+                module_name,
+                inst_scope,
+                inst.project_path,
+            )
+            if not plugin_root.exists():
+                console.print(
+                    f"[yellow]Plugin not found: {plugin_root}[/yellow]",
+                )
+                continue
+            shutil.rmtree(plugin_root)
+            removed_count += 1
+            if verbose:
+                console.print(
+                    f"  [green]Removed plugin {plugin_root}[/green]",
+                )
+            registry.remove(
+                module_name,
+                assistant=inst.assistant,
+                scope=inst.scope,
+                project_path=inst.project_path,
+            )
+            continue
+
         # Remove skill files
         if inst.skills:
             skill_dest = target.get_skill_path(path_context, inst_scope)
@@ -1312,20 +1365,6 @@ def uninstall_cmd(
                 if verbose:
                     console.print(f"  [green]Removed MCPs from {mcp_dest}[/green]")
 
-        # Remove plugin directory if it exists
-        layout = target.get_plugin_layout(inst_scope)
-        if layout is not None:
-            plugin_root = layout.resolve_root(
-                module_name,
-                inst_scope,
-                inst.project_path,
-            )
-            if plugin_root.exists():
-                shutil.rmtree(plugin_root)
-                removed_count += 1
-                if verbose:
-                    console.print(f"  [green]Removed plugin {plugin_root}[/green]")
-
         # Also remove the project-local module copy
         if inst.scope == "project" and inst.project_path:
             local_modules = get_local_modules_path(inst.project_path)
@@ -1360,7 +1399,9 @@ def uninstall_cmd(
         )
 
     console.print(
-        f"[green]Uninstalled from {len(installations)} installation{'s' if len(installations) != 1 else ''}[/green]"
+        f"[green]Uninstalled from {removed_count} installation{'s' if removed_count != 1 else ''}[/green]"
+        if removed_count > 0
+        else "[yellow]Nothing was uninstalled[/yellow]"
     )
 
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -769,6 +769,13 @@ def _format_update_summary(result: UpdateResult) -> str:
     default="project",
     help="Installation scope: project (default) or user",
 )
+@click.option(
+    "--plugin",
+    "as_plugin",
+    is_flag=True,
+    default=False,
+    help="Install as a self-contained plugin bundle",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -780,6 +787,7 @@ def install_cmd(
     append_context: tuple[str, ...],
     workspace: Optional[str],
     scope: str,
+    as_plugin: bool,
     project_path: str,
 ):
     """
@@ -984,8 +992,35 @@ def install_cmd(
     # Convert CLI tuple to list for the rest of the flow
     append_context_list = list(append_context) if append_context else None
 
+    # Some clients don't support plugins; others support only specific scopes
+    # (e.g. user but not project). When -a is explicit, exit on unsupported.
+    if as_plugin and assistant is not None:
+        target = get_target(assistant)
+        if target.get_plugin_layout(scope) is None:
+            if (
+                target.get_plugin_layout("user") is None
+                and target.get_plugin_layout("project") is None
+            ):
+                console.print(
+                    f"[red]--plugin is not supported with {assistant}[/red]",
+                )
+            else:
+                console.print(
+                    f"[red]{scope}-level plugin is not supported for {assistant}[/red]",
+                )
+            raise SystemExit(1)
+
     total_installed = 0
     for asst in assistants_to_install:
+        # In plugin mode without -a, skip clients that don't support plugins.
+        if as_plugin:
+            target = get_target(asst)
+            if target.get_plugin_layout(scope) is None:
+                console.print(
+                    f"  [dim]{asst}: plugin not supported"
+                    f" at {scope} scope, skipping[/dim]",
+                )
+                continue
         total_installed += install_to_assistant(
             module,
             asst,
@@ -998,6 +1033,7 @@ def install_cmd(
             effective_pre_install,
             effective_post_install,
             append_context_list,
+            as_plugin=as_plugin,
         )
 
     # Update installation records with version/ref from marketplace metadata

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1021,7 +1021,7 @@ def install_cmd(
                     f" at {scope} scope, skipping[/dim]",
                 )
                 continue
-        total_installed += install_to_assistant(
+        result = install_to_assistant(
             module,
             asst,
             scope,
@@ -1035,6 +1035,8 @@ def install_cmd(
             append_context_list,
             as_plugin=as_plugin,
         )
+        if result > 0:
+            total_installed += 1
 
     # Update installation records with version/ref from marketplace metadata
     if module_dict:

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1428,7 +1428,19 @@ def uninstall_cmd(
     is_flag=True,
     help="Show detailed output for each skill and command",
 )
-def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bool):
+@click.option(
+    "--plugin",
+    "as_plugin",
+    is_flag=True,
+    default=False,
+    help="Update a plugin bundle (reinstalls from source)",
+)
+def update_cmd(
+    module_name: Optional[str],
+    assistant: Optional[str],
+    verbose: bool,
+    as_plugin: bool,
+):
     """
     Regenerate assistant files from source in .lola/modules/.
 
@@ -1486,12 +1498,72 @@ def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bo
                 console.print(f'  [dim]path:[/dim] "{project_path}"')
 
             for inst in scope_insts:
+                # Check for mode mismatch
+                if as_plugin and not inst.is_plugin:
+                    console.print(
+                        f"    [red]{inst.assistant}: installed as"
+                        f" standard, use --plugin to reinstall"
+                        f" or uninstall first[/red]",
+                    )
+                    continue
+                if not as_plugin and inst.is_plugin:
+                    console.print(
+                        f"    [red]{inst.assistant}: installed as"
+                        f" a plugin, use --plugin to update[/red]",
+                    )
+                    continue
+
                 # Validate installation
                 is_valid, error_msg = _validate_installation_for_update(inst)
                 if not is_valid:
                     console.print(f"    [red]{inst.assistant}: {error_msg}[/red]")
                     if error_msg == "project path no longer exists":
                         stale_installations.append(inst)
+                    continue
+
+                # Plugin update: uninstall and reinstall
+                if as_plugin and inst.is_plugin:
+                    target = get_target(inst.assistant)
+                    layout = target.get_plugin_layout(inst.scope)
+                    if layout:
+                        plugin_root = layout.resolve_root(
+                            inst.module_name,
+                            inst.scope,
+                            inst.project_path,
+                        )
+                        if plugin_root.exists():
+                            shutil.rmtree(plugin_root)
+                    global_module = load_registered_module(
+                        MODULES_DIR / inst.module_name,
+                    )
+                    if not global_module:
+                        console.print(
+                            f"    [red]{inst.assistant}: module not found[/red]",
+                        )
+                        continue
+                    if inst.scope == "user":
+                        local_modules = get_local_modules_path(
+                            str(Path.cwd()),
+                        )
+                    else:
+                        local_modules = get_local_modules_path(
+                            inst.project_path,
+                        )
+                    count = install_to_assistant(
+                        module=global_module,
+                        assistant=inst.assistant,
+                        scope=inst.scope,
+                        project_path=inst.project_path,
+                        local_modules=local_modules,
+                        registry=registry,
+                        verbose=verbose,
+                        force=True,
+                        as_plugin=True,
+                    )
+                    console.print(
+                        f"    [green]{inst.assistant}[/green]"
+                        f" [dim](reinstalled, {count} items)[/dim]",
+                    )
                     continue
 
                 # Build context for update

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1312,6 +1312,20 @@ def uninstall_cmd(
                 if verbose:
                     console.print(f"  [green]Removed MCPs from {mcp_dest}[/green]")
 
+        # Remove plugin directory if it exists
+        layout = target.get_plugin_layout(inst_scope)
+        if layout is not None:
+            plugin_root = layout.resolve_root(
+                module_name,
+                inst_scope,
+                inst.project_path,
+            )
+            if plugin_root.exists():
+                shutil.rmtree(plugin_root)
+                removed_count += 1
+                if verbose:
+                    console.print(f"  [green]Removed plugin {plugin_root}[/green]")
+
         # Also remove the project-local module copy
         if inst.scope == "project" and inst.project_path:
             local_modules = get_local_modules_path(inst.project_path)

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1058,9 +1058,12 @@ def install_cmd(
                         registry.add(inst)  # Update the record
 
     console.print()
-    console.print(
-        f"[green]Installed to {len(assistants_to_install)} assistant{'s' if len(assistants_to_install) != 1 else ''}[/green]"
-    )
+    if total_installed > 0:
+        console.print(
+            f"[green]Installed to {len(assistants_to_install)} assistant{'s' if len(assistants_to_install) != 1 else ''}[/green]"
+        )
+    else:
+        console.print("[yellow]Nothing was installed[/yellow]")
 
 
 @click.command(name="uninstall")

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -805,21 +805,30 @@ def remove_module(module_name: str | None, force: bool):
 
     # Uninstall from all locations
     for inst in installations:
-        if not inst.project_path:
-            continue
-
         target = get_target(inst.assistant)
-        skill_dest = target.get_skill_path(inst.project_path, inst.scope)
 
-        # Remove generated skill files
-        if target.uses_managed_section:
-            # Remove module section from managed file (e.g., GEMINI.md, AGENTS.md)
-            if target.remove_skill(skill_dest, module_name):
-                console.print(f"  [dim]Removed from: {skill_dest}[/dim]")
-        else:
-            for skill in inst.skills:
-                if target.remove_skill(skill_dest, skill):
-                    console.print(f"  [dim]Removed: {skill}[/dim]")
+        # Remove plugin directory if this was a plugin install
+        if inst.is_plugin:
+            layout = target.get_plugin_layout(inst.scope)
+            if layout is not None:
+                plugin_root = layout.resolve_root(
+                    module_name,
+                    inst.scope,
+                    inst.project_path,
+                )
+                if plugin_root.exists():
+                    shutil.rmtree(plugin_root)
+                    console.print(f"  [dim]Removed: {plugin_root}[/dim]")
+        elif inst.project_path:
+            skill_dest = target.get_skill_path(inst.project_path, inst.scope)
+
+            if target.uses_managed_section:
+                if target.remove_skill(skill_dest, module_name):
+                    console.print(f"  [dim]Removed from: {skill_dest}[/dim]")
+            else:
+                for skill in inst.skills:
+                    if target.remove_skill(skill_dest, skill):
+                        console.print(f"  [dim]Removed: {skill}[/dim]")
 
         # Remove source files from project .lola/modules/ if applicable
         if inst.project_path:

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -776,6 +776,7 @@ class Installation:
     mcps: list[str] = field(default_factory=list)
     has_instructions: bool = False
     append_context: list[str] | None = None
+    is_plugin: bool = False
 
     def __post_init__(self) -> None:
         """Validate append_context items are strings."""
@@ -807,6 +808,7 @@ class Installation:
             result["ref"] = self.ref
         if self.append_context:
             result["append_context"] = self.append_context
+        result["is_plugin"] = self.is_plugin
         return result
 
     @classmethod
@@ -838,6 +840,7 @@ class Installation:
             mcps=data.get("mcps", []),
             has_instructions=data.get("has_instructions", False),
             append_context=append_context,
+            is_plugin=data.get("is_plugin", False),
         )
 
 

--- a/src/lola/targets/__init__.py
+++ b/src/lola/targets/__init__.py
@@ -19,6 +19,7 @@ from lola.targets.base import (
     ManagedSectionTarget,
     MCPSupportMixin,
     PluginLayout,
+    PluginManifest,
     _convert_env_var_to_cursor_vscode,
     _convert_env_var_to_opencode,
     _generate_agent_with_frontmatter,
@@ -99,6 +100,7 @@ __all__ = [
     "ManagedSectionTarget",
     "MCPSupportMixin",
     "PluginLayout",
+    "PluginManifest",
     # Concrete targets
     "ClaudeCodeTarget",
     "CopilotCliTarget",

--- a/src/lola/targets/__init__.py
+++ b/src/lola/targets/__init__.py
@@ -18,6 +18,7 @@ from lola.targets.base import (
     ManagedInstructionsTarget,
     ManagedSectionTarget,
     MCPSupportMixin,
+    PluginLayout,
     _convert_env_var_to_cursor_vscode,
     _convert_env_var_to_opencode,
     _generate_agent_with_frontmatter,
@@ -97,6 +98,7 @@ __all__ = [
     "ManagedInstructionsTarget",
     "ManagedSectionTarget",
     "MCPSupportMixin",
+    "PluginLayout",
     # Concrete targets
     "ClaudeCodeTarget",
     "CopilotCliTarget",

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -145,6 +145,30 @@ class PluginManifest:
         if not self.name:
             raise ValueError("PluginManifest requires a non-empty name")
 
+    @classmethod
+    def from_file(cls, path: Path) -> PluginManifest | None:
+        """Load from an existing plugin.json. Returns None if not found or invalid."""
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        name = data.get("name")
+        if not name:
+            return None
+        return cls(
+            name=name,
+            version=data.get("version"),
+            description=data.get("description"),
+            author=data.get("author"),
+            homepage=data.get("homepage"),
+            repository=data.get("repository"),
+            license=data.get("license"),
+            keywords=data.get("keywords"),
+            extensions=data.get("extensions"),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {"$schema": _PLUGIN_SCHEMA, "name": self.name}
         if self.version:

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 import yaml
 
 import lola.frontmatter as fm
+from lola.models import Module
 
 
 def unlink_symlink_if_present(path: Path) -> None:
@@ -117,6 +118,61 @@ def _resolve_source_content(source: Path | str | list[str]) -> str | None:
     elif isinstance(source, str):
         return source.strip()
     return None
+
+
+# =============================================================================
+# Plugin manifest
+# =============================================================================
+
+_PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+
+
+@dataclass
+class PluginManifest:
+    """Plugin manifest (plugin.json) per the Open Plugin Spec."""
+
+    name: str
+    version: str | None = None
+    description: str | None = None
+    author: dict[str, str] | None = None
+    homepage: str | None = None
+    repository: str | None = None
+    license: str | None = None
+    keywords: list[str] | None = None
+    extensions: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("PluginManifest requires a non-empty name")
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"$schema": _PLUGIN_SCHEMA, "name": self.name}
+        if self.version:
+            result["version"] = self.version
+        if self.description:
+            result["description"] = self.description
+        if self.author:
+            result["author"] = {
+                k: v for k, v in self.author.items() if k in {"name", "email", "url"}
+            }
+        if self.homepage:
+            result["homepage"] = self.homepage
+        if self.repository:
+            result["repository"] = self.repository
+        if self.license:
+            result["license"] = self.license
+        if self.keywords:
+            result["keywords"] = self.keywords
+        if self.extensions:
+            result["extensions"] = self.extensions
+        return result
+
+    def write(self, manifest_dir: Path) -> bool:
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        (manifest_dir / "plugin.json").write_text(
+            json.dumps(self.to_dict(), indent=2) + "\n"
+        )
+        return True
 
 
 # =============================================================================
@@ -379,6 +435,10 @@ class AssistantTarget(ABC):
     ) -> PluginLayout | None:
         """Return plugin layout, or None if not supported."""
         return None
+
+    def build_plugin_manifest(self, module: Module) -> PluginManifest:
+        """Build plugin manifest. Override in targets that support plugins."""
+        raise NotImplementedError(f"{self.name} does not support plugins")
 
 
 # =============================================================================

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -129,7 +129,12 @@ _PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 
 @dataclass
 class PluginManifest:
-    """Plugin manifest (plugin.json) per the Open Plugin Spec."""
+    """Plugin manifest (plugin.json) per the Open Plugin Spec.
+
+    Based on the docs https://agent-plugins.org/plugin-authors/manifest the schema is closed,
+    Do not add any new properties to this class without checking the schema.
+    If adding a new property, make sure to update the the to_dict and from_file methods.
+    """
 
     name: str
     version: str | None = None

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -168,7 +168,7 @@ class PluginManifest:
             name=name,
             version=data.get("version"),
             description=data.get("description"),
-            author=data.get("author"),
+            author=data.get("author") if isinstance(data.get("author"), dict) else None,
             homepage=data.get("homepage"),
             repository=data.get("repository"),
             license=data.get("license"),

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -18,6 +18,7 @@ import re
 import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -116,6 +117,52 @@ def _resolve_source_content(source: Path | str | list[str]) -> str | None:
     elif isinstance(source, str):
         return source.strip()
     return None
+
+
+# =============================================================================
+# Plugin layout
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PluginLayout:
+    """Plugin directory structure for a target."""
+
+    plugin_root_template: str
+    manifest_path: str | None
+    mcp_path: str | None
+    skills_path: str = "skills"
+    agents_path: str | None = "agents"
+    commands_path: str | None = "commands"
+    instructions_path: str | None = None
+
+    def resolve_root(
+        self, module_name: str, scope: str, project_path: str | None
+    ) -> Path:
+        """Resolve the plugin root directory from the template."""
+        template = self.plugin_root_template.format(name=module_name)
+        if template.startswith("~/"):
+            return Path.home() / template[2:]
+        if scope == "project" and project_path:
+            return Path(project_path) / template
+        return Path(template)
+
+    def resolve_paths(self, plugin_root: Path) -> dict[str, Path | None]:
+        """Resolve all component paths relative to plugin root."""
+        return {
+            "skills": plugin_root / self.skills_path,
+            "commands": plugin_root / self.commands_path
+            if self.commands_path
+            else None,
+            "agents": plugin_root / self.agents_path if self.agents_path else None,
+            "mcp": plugin_root / self.mcp_path if self.mcp_path else None,
+            "instructions": plugin_root / self.instructions_path
+            if self.instructions_path
+            else None,
+            "manifest": plugin_root / self.manifest_path
+            if self.manifest_path
+            else plugin_root,
+        }
 
 
 # =============================================================================
@@ -325,6 +372,13 @@ class AssistantTarget(ABC):
             Returns True immediately if supports_agents is False.
         """
         ...
+
+    def get_plugin_layout(
+        self,
+        scope: str = "project",
+    ) -> PluginLayout | None:
+        """Return plugin layout, or None if not supported."""
+        return None
 
 
 # =============================================================================

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -159,6 +159,8 @@ class PluginManifest:
             data = json.loads(path.read_text())
         except (json.JSONDecodeError, OSError):
             return None
+        if not isinstance(data, dict):
+            return None
         name = data.get("name")
         if not name:
             return None

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -6,11 +6,13 @@ import shutil
 from pathlib import Path
 
 import lola.config as config
+from lola.models import Module
 from .base import (
     BaseAssistantTarget,
     ManagedInstructionsTarget,
     MCPSupportMixin,
     PluginLayout,
+    PluginManifest,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
     _transform_claude_agent_frontmatter,
@@ -37,6 +39,9 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
             manifest_path=".claude-plugin",
             mcp_path=".mcp.json",
         )
+
+    def build_plugin_manifest(self, module: Module) -> PluginManifest:
+        return PluginManifest(name=module.name)
 
     def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -10,6 +10,7 @@ from .base import (
     BaseAssistantTarget,
     ManagedInstructionsTarget,
     MCPSupportMixin,
+    PluginLayout,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
     _transform_claude_agent_frontmatter,
@@ -23,6 +24,19 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
     name = "claude-code"
     supports_agents = True
     INSTRUCTIONS_FILE = "CLAUDE.md"
+
+    def get_plugin_layout(
+        self,
+        scope: str = "project",
+    ) -> PluginLayout | None:
+        template = (
+            "~/.claude/skills/{name}" if scope == "user" else ".claude/skills/{name}"
+        )
+        return PluginLayout(
+            plugin_root_template=template,
+            manifest_path=".claude-plugin",
+            mcp_path=".mcp.json",
+        )
 
     def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -41,6 +41,9 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         )
 
     def build_plugin_manifest(self, module: Module) -> PluginManifest:
+        existing = PluginManifest.from_file(module.content_path / "plugin.json")
+        if existing is not None:
+            return existing
         return PluginManifest(name=module.name)
 
     def get_skill_path(self, project_path: str, scope: str = "project") -> Path:

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -14,9 +14,12 @@ from pathlib import Path
 from typing import Any
 
 import lola.config as config
+from lola.models import Module
 from .base import (
     MCPSupportMixin,
     BaseAssistantTarget,
+    PluginLayout,
+    PluginManifest,
     _convert_env_var_to_cursor_vscode,
     _generate_passthrough_command,
     _generate_agent_with_frontmatter,
@@ -32,6 +35,26 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
 
     name = "cursor"
     supports_agents = True
+
+    def get_plugin_layout(
+        self,
+        scope: str = "project",
+    ) -> PluginLayout | None:
+        if scope == "project":
+            return None
+        # Uses the Agent Plugin (global spec) format with plugin.json at root,
+        # not Cursor's own format (.cursor-plugin/plugin.json).
+        return PluginLayout(
+            plugin_root_template="~/.cursor/plugins/local/{name}",
+            manifest_path=None,
+            mcp_path="mcp.json",
+        )
+
+    def build_plugin_manifest(self, module: Module) -> PluginManifest:
+        existing = PluginManifest.from_file(module.content_path / "plugin.json")
+        if existing is not None:
+            return existing
+        return PluginManifest(name=module.name)
 
     def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -860,6 +860,7 @@ def install_to_assistant(
                 mcps=installed_mcps,
                 has_instructions=instructions_installed,
                 append_context=append_context,
+                is_plugin=as_plugin,
             )
         )
 

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -810,15 +810,20 @@ def install_to_assistant(
         dest_override=paths["mcp"] if paths else None,
     )
 
-    instructions_installed = _install_instructions(
-        target,
-        module,
-        local_module_path,
-        project_path,
-        append_context,
-        scope,
-        dest_override=paths["instructions"] if paths else None,
-    )
+    # In plugin mode, skip instructions if the layout has no instructions path
+    # to avoid writing outside the plugin bundle.
+    if as_plugin and (not paths or not paths.get("instructions")):
+        instructions_installed = False
+    else:
+        instructions_installed = _install_instructions(
+            target,
+            module,
+            local_module_path,
+            project_path,
+            append_context,
+            scope,
+            dest_override=paths["instructions"] if paths else None,
+        )
 
     plugin_manifest_installed = _install_plugin_manifest(
         as_plugin, paths, target, module

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -611,17 +611,15 @@ def _install_mcps(
 
 def _install_plugin_manifest(
     as_plugin: bool,
-    manifest_dir: Path | None,
+    paths: dict[str, Path | None] | None,
+    target: AssistantTarget,
     module: Module,
 ) -> bool:
     """Generate plugin.json manifest. Returns True if generated."""
+    manifest_dir = paths.get("manifest") if paths else None
     if not as_plugin or manifest_dir is None:
         return False
-    manifest_dir.mkdir(parents=True, exist_ok=True)
-    manifest: dict[str, str] = {"name": module.name}
-    manifest_path = manifest_dir / "plugin.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-    return True
+    return target.build_plugin_manifest(module).write(manifest_dir)
 
 
 def _print_summary(
@@ -823,9 +821,7 @@ def install_to_assistant(
     )
 
     plugin_manifest_installed = _install_plugin_manifest(
-        as_plugin,
-        paths["manifest"] if paths else None,
-        module,
+        as_plugin, paths, target, module
     )
 
     _print_summary(

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -714,6 +714,31 @@ def install_to_assistant(
 
     target = get_target(assistant)
 
+    # Check for mode mismatch with existing installation
+    existing = [
+        inst
+        for inst in registry.find(module.name)
+        if inst.assistant == assistant
+        and inst.scope == scope
+        and inst.project_path == project_path
+    ]
+    if existing:
+        inst = existing[0]
+        if as_plugin and not inst.is_plugin:
+            console.print(
+                f"[red]{module.name} is installed as standard"
+                f" for {assistant}, use --plugin to reinstall"
+                f" as a plugin or uninstall first[/red]",
+            )
+            return 0
+        if not as_plugin and inst.is_plugin:
+            console.print(
+                f"[red]{module.name} is installed as a plugin"
+                f" for {assistant}, uninstall with --plugin"
+                f" first[/red]",
+            )
+            return 0
+
     paths: dict[str, Path | None] | None = None
 
     if as_plugin:

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -267,6 +267,7 @@ def _install_skills(
     project_path: str | None,
     scope: str = "project",
     force: bool = False,
+    dest_override: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install skills for a target. Returns (installed, failed) lists."""
     if not module.skills:
@@ -277,7 +278,10 @@ def _install_skills(
 
     # For user scope, project_path may be None
     path_context = project_path or ""
-    skill_dest = target.get_skill_path(path_context, scope)
+    skill_dest = dest_override or target.get_skill_path(
+        path_context,
+        scope,
+    )
 
     content_dirname = _get_content_dirname(module)
 
@@ -352,6 +356,7 @@ def _install_commands(
     project_path: str | None,
     force: bool = False,
     scope: str = "project",
+    dest_override: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install commands for a target. Returns (installed, failed) lists."""
     if not module.commands:
@@ -361,7 +366,10 @@ def _install_commands(
     failed: list[str] = []
 
     path_context = project_path or ""
-    command_dest = target.get_command_path(path_context, scope)
+    command_dest = dest_override or target.get_command_path(
+        path_context,
+        scope,
+    )
 
     if command_dest is None:
         console.print(
@@ -413,13 +421,17 @@ def _install_agents(
     project_path: str | None,
     force: bool = False,
     scope: str = "project",
+    dest_override: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install agents for a target. Returns (installed, failed) lists."""
     if not module.agents or not target.supports_agents:
         return [], []
 
     path_context = project_path or ""
-    agent_dest = target.get_agent_path(path_context, scope)
+    agent_dest = dest_override or target.get_agent_path(
+        path_context,
+        scope,
+    )
     if not agent_dest:
         return [], []
 
@@ -467,6 +479,7 @@ def _install_instructions(
     project_path: str | None,
     append_context: list[str] | None = None,
     scope: str = "project",
+    dest_override: Path | None = None,
 ) -> bool:
     """Install module instructions for a target. Returns True if installed."""
     from lola.models import INSTRUCTIONS_FILE
@@ -477,8 +490,10 @@ def _install_instructions(
     if scope == "project" and not project_path:
         return False
 
-    # Type checker: at this point project_path is guaranteed to be a string
-    instructions_dest = target.get_instructions_path(cast(str, project_path), scope)
+    instructions_dest = dest_override or target.get_instructions_path(
+        cast(str, project_path),
+        scope,
+    )
 
     # --append-context: insert references instead of verbatim copy
     if append_context:
@@ -553,13 +568,17 @@ def _install_mcps(
     local_module_path: Path,
     project_path: str | None,
     scope: str = "project",
+    dest_override: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install MCPs for a target. Returns (installed, failed) lists."""
     if not module.mcps:
         return [], []
 
     path_context = project_path or ""
-    mcp_dest = target.get_mcp_path(path_context, scope)
+    mcp_dest = dest_override or target.get_mcp_path(
+        path_context,
+        scope,
+    )
     if mcp_dest is None:
         console.print(
             f"  [yellow]MCP servers are not supported by {target.name} "
@@ -590,6 +609,21 @@ def _install_mcps(
     return [], list(module.mcps)
 
 
+def _install_plugin_manifest(
+    as_plugin: bool,
+    manifest_dir: Path | None,
+    module: Module,
+) -> bool:
+    """Generate plugin.json manifest. Returns True if generated."""
+    if not as_plugin or manifest_dir is None:
+        return False
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, str] = {"name": module.name}
+    manifest_path = manifest_dir / "plugin.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return True
+
+
 def _print_summary(
     assistant: str,
     installed_skills: list[str],
@@ -597,6 +631,7 @@ def _print_summary(
     installed_agents: list[str],
     installed_mcps: list[str],
     has_instructions: bool,
+    has_plugin_manifest: bool,
     failed_skills: list[str],
     failed_commands: list[str],
     failed_agents: list[str],
@@ -611,6 +646,7 @@ def _print_summary(
         or installed_agents
         or installed_mcps
         or has_instructions
+        or has_plugin_manifest
     ):
         return
 
@@ -633,6 +669,8 @@ def _print_summary(
         )
     if has_instructions:
         parts.append("instructions")
+    if has_plugin_manifest:
+        parts.append("plugin.json")
 
     console.print(f"  [green]{assistant}[/green] [dim]({', '.join(parts)})[/dim]")
 
@@ -671,12 +709,54 @@ def install_to_assistant(
     pre_install_script: Optional[str] = None,
     post_install_script: Optional[str] = None,
     append_context: Optional[list[str]] = None,
+    as_plugin: bool = False,
 ) -> int:
     """Install module to a specific assistant."""
-    # Late import to avoid circular imports - get_target is defined in __init__.py
     from lola.targets import get_target
 
     target = get_target(assistant)
+
+    paths: dict[str, Path | None] | None = None
+
+    if as_plugin:
+        layout = target.get_plugin_layout(scope)
+        if layout is None:
+            raise InstallationError(
+                module.name,
+                assistant,
+                f"Plugin install is not supported for {assistant} at {scope} scope",
+            )
+
+        plugin_root = layout.resolve_root(
+            module.name,
+            scope,
+            project_path,
+        )
+
+        if plugin_root.exists() and not force:
+            if is_interactive():
+                if not click.confirm(
+                    f"Plugin '{module.name}' already exists"
+                    f" at {plugin_root}. Overwrite?",
+                    default=False,
+                ):
+                    console.print(
+                        f"  [yellow]Skipped {assistant}[/yellow]",
+                    )
+                    return 0
+            else:
+                console.print(
+                    f"  [yellow]{assistant}: plugin already"
+                    f" exists, skipping (use --force to"
+                    f" overwrite)[/yellow]",
+                )
+                return 0
+
+        paths = layout.resolve_paths(plugin_root)
+
+        if plugin_root.exists():
+            shutil.rmtree(plugin_root)
+        plugin_root.mkdir(parents=True, exist_ok=True)
 
     local_module_path = copy_module_to_local(module, local_modules)
 
@@ -697,19 +777,55 @@ def install_to_assistant(
             raise
 
     installed_skills, failed_skills = _install_skills(
-        target, module, local_module_path, project_path, scope, force
+        target,
+        module,
+        local_module_path,
+        project_path,
+        scope,
+        force,
+        dest_override=paths["skills"] if paths else None,
     )
     installed_commands, failed_commands = _install_commands(
-        target, module, local_module_path, project_path, force, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        force,
+        scope,
+        dest_override=paths["commands"] if paths else None,
     )
     installed_agents, failed_agents = _install_agents(
-        target, module, local_module_path, project_path, force, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        force,
+        scope,
+        dest_override=paths["agents"] if paths else None,
     )
     installed_mcps, failed_mcps = _install_mcps(
-        target, module, local_module_path, project_path, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        scope,
+        dest_override=paths["mcp"] if paths else None,
     )
+
     instructions_installed = _install_instructions(
-        target, module, local_module_path, project_path, append_context, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        append_context,
+        scope,
+        dest_override=paths["instructions"] if paths else None,
+    )
+
+    plugin_manifest_installed = _install_plugin_manifest(
+        as_plugin,
+        paths["manifest"] if paths else None,
+        module,
     )
 
     _print_summary(
@@ -719,6 +835,7 @@ def install_to_assistant(
         installed_agents,
         installed_mcps,
         instructions_installed,
+        plugin_manifest_installed,
         failed_skills,
         failed_commands,
         failed_agents,
@@ -733,6 +850,7 @@ def install_to_assistant(
         or installed_agents
         or installed_mcps
         or instructions_installed
+        or plugin_manifest_installed
     ):
         registry.add(
             Installation(
@@ -773,6 +891,7 @@ def install_to_assistant(
         + len(installed_agents)
         + len(installed_mcps)
         + (1 if instructions_installed else 0)
+        + (1 if plugin_manifest_installed else 0)
     )
 
 

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -1011,12 +1011,32 @@ def _uninstall_mcps(
     return [], list(inst.mcps)
 
 
+def _uninstall_plugin(
+    target: AssistantTarget,
+    inst: Installation,
+) -> tuple[list[str], list[str]]:
+    """Remove plugin directory if it exists. Returns (removed, failed)."""
+    layout = target.get_plugin_layout(inst.scope)
+    if layout is None:
+        return [], []
+    plugin_root = layout.resolve_root(
+        inst.module_name,
+        inst.scope,
+        inst.project_path,
+    )
+    if not plugin_root.exists():
+        return [], []
+    shutil.rmtree(plugin_root)
+    return [inst.module_name], []
+
+
 def _print_uninstall_summary(
     assistant: str,
     removed_skills: list[str],
     removed_commands: list[str],
     removed_agents: list[str],
     removed_mcps: list[str],
+    removed_plugin: list[str],
     had_instructions: bool,
     module_name: str,
     verbose: bool,
@@ -1027,6 +1047,7 @@ def _print_uninstall_summary(
         or removed_commands
         or removed_agents
         or removed_mcps
+        or removed_plugin
         or had_instructions
     ):
         return
@@ -1048,6 +1069,8 @@ def _print_uninstall_summary(
         parts.append(f"{len(removed_mcps)} MCP{'s' if len(removed_mcps) != 1 else ''}")
     if had_instructions:
         parts.append("instructions")
+    if removed_plugin:
+        parts.append("plugin.json")
 
     console.print(f"  [green]{assistant}[/green] [dim]({', '.join(parts)})[/dim]")
 
@@ -1091,6 +1114,7 @@ def uninstall_from_assistant(
     removed_agents, _ = _uninstall_agents(target, inst)
     removed_mcps, _ = _uninstall_mcps(target, inst)
     instructions_removed = _uninstall_instructions(target, inst)
+    removed_plugin, _ = _uninstall_plugin(target, inst)
 
     _print_uninstall_summary(
         inst.assistant,
@@ -1098,6 +1122,7 @@ def uninstall_from_assistant(
         removed_commands,
         removed_agents,
         removed_mcps,
+        removed_plugin,
         instructions_removed,
         inst.module_name,
         verbose,

--- a/tests/test_claude_code_target.py
+++ b/tests/test_claude_code_target.py
@@ -1,6 +1,8 @@
 """Tests for ClaudeCodeTarget scope-aware path resolution."""
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from lola.targets.claude_code import ClaudeCodeTarget
 
@@ -99,3 +101,59 @@ def test_claude_code_mcp_path_default_scope():
     target = ClaudeCodeTarget()
     result = target.get_mcp_path("/home/user/project")
     assert result == Path("/home/user/project/.mcp.json")
+
+
+# --- Plugin tests ---
+
+
+def test_claude_code_plugin_layout_project():
+    target = ClaudeCodeTarget()
+    layout = target.get_plugin_layout("project")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "project", "/home/user/project")
+    assert root == Path("/home/user/project/.claude/skills/my-pack")
+
+
+def test_claude_code_plugin_layout_user():
+    target = ClaudeCodeTarget()
+    layout = target.get_plugin_layout("user")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "user", None)
+    assert root == Path.home() / ".claude" / "skills" / "my-pack"
+
+
+def test_claude_code_plugin_layout_manifest_path():
+    target = ClaudeCodeTarget()
+    layout = target.get_plugin_layout("project")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "project", "/project")
+    paths = layout.resolve_paths(root)
+    assert paths["manifest"] == root / ".claude-plugin"
+
+
+def test_claude_code_plugin_layout_mcp_path():
+    target = ClaudeCodeTarget()
+    layout = target.get_plugin_layout("project")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "project", "/project")
+    paths = layout.resolve_paths(root)
+    assert paths["mcp"] == root / ".mcp.json"
+
+
+def test_claude_code_build_manifest_uses_existing(tmp_path):
+    target = ClaudeCodeTarget()
+    (tmp_path / "plugin.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                "name": "from-pack",
+                "version": "2.0.0",
+            }
+        )
+    )
+    module = MagicMock()
+    module.name = "my-pack"
+    module.content_path = tmp_path
+    manifest = target.build_plugin_manifest(module)
+    assert manifest.name == "from-pack"
+    assert manifest.version == "2.0.0"

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -605,6 +605,7 @@ class TestUninstallCmd:
         mock_target.get_command_path.return_value = command_dest
         mock_target.get_command_filename.return_value = "mymodule.cmd1.md"
         mock_target.remove_skill.return_value = True
+        mock_target.get_plugin_layout.return_value = None
 
         with (
             patch("lola.cli.install.ensure_lola_dirs"),

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,6 +1,7 @@
 """Tests for the install CLI commands."""
 
 import shutil
+from pathlib import Path
 from unittest.mock import patch
 
 from lola.cli.install import (
@@ -616,6 +617,167 @@ class TestUninstallCmd:
 
         assert result.exit_code == 0
         assert "Uninstalled" in result.output
+
+    def test_plugin_install_plugin_uninstall(self, cli_runner, tmp_path):
+        """Uninstall a plugin with --plugin removes plugin directory."""
+        from unittest.mock import MagicMock
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        registry = InstallationRegistry(installed_file)
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir()
+        registry.add(
+            Installation(
+                module_name="mymodule",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+                is_plugin=True,
+            )
+        )
+
+        plugin_dir = Path(project_path) / ".claude" / "skills" / "mymodule"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text('{"name": "mymodule"}')
+
+        from lola.targets.base import PluginLayout
+
+        layout = PluginLayout(
+            plugin_root_template=".claude/skills/{name}",
+            manifest_path=".claude-plugin",
+            mcp_path=".mcp.json",
+        )
+        mock_target = MagicMock()
+        mock_target.get_plugin_layout.return_value = layout
+        mock_target.get_plugin_layout.return_value = layout
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = cli_runner.invoke(
+                uninstall_cmd,
+                ["mymodule", "--plugin", "-f"],
+            )
+
+        assert result.exit_code == 0
+        assert not plugin_dir.exists()
+
+    def test_plugin_install_standard_uninstall(self, cli_runner, tmp_path):
+        """Uninstall a plugin without --plugin shows error."""
+        from unittest.mock import MagicMock
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mymodule",
+                assistant="cursor",
+                scope="user",
+                skills=["skill1"],
+                is_plugin=True,
+            )
+        )
+
+        mock_target = MagicMock()
+        mock_target.get_plugin_layout.return_value = None
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = cli_runner.invoke(
+                uninstall_cmd,
+                ["mymodule", "-f"],
+            )
+
+        assert "installed as a plugin" in result.output
+        assert "Nothing was uninstalled" in result.output
+
+    def test_standard_install_plugin_uninstall(self, cli_runner, tmp_path):
+        """Uninstall a standard install with --plugin shows error."""
+        from unittest.mock import MagicMock
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mymodule",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+                is_plugin=False,
+            )
+        )
+
+        mock_target = MagicMock()
+        mock_target.get_plugin_layout.return_value = None
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = cli_runner.invoke(
+                uninstall_cmd,
+                ["mymodule", "--plugin", "-f"],
+            )
+
+        assert "not installed as a plugin" in result.output
+        assert "Nothing was uninstalled" in result.output
+
+    def test_standard_install_standard_uninstall(self, cli_runner, tmp_path):
+        """Uninstall a standard install without --plugin works."""
+        from unittest.mock import MagicMock
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        registry = InstallationRegistry(installed_file)
+
+        skill_dest = tmp_path / "skills"
+        skill_dir = skill_dest / "skill1"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("content")
+
+        registry.add(
+            Installation(
+                module_name="mymodule",
+                assistant="cursor",
+                scope="user",
+                skills=["skill1"],
+                is_plugin=False,
+            )
+        )
+
+        mock_target = MagicMock()
+        mock_target.get_skill_path.return_value = skill_dest
+        mock_target.get_command_path.return_value = None
+        mock_target.get_agent_path.return_value = None
+        mock_target.uses_managed_section = False
+        mock_target.remove_skill.return_value = True
+        mock_target.get_plugin_layout.return_value = None
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = cli_runner.invoke(
+                uninstall_cmd,
+                ["mymodule", "-f"],
+            )
+
+        assert result.exit_code == 0
+        assert "Uninstalled from 1 installation" in result.output
 
 
 class TestUpdateCmd:

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -1434,6 +1434,53 @@ class TestModRemoveAdvanced:
         # CRITICAL: Verify get_skill_path was called with the correct scope
         mock_target.get_skill_path.assert_called_once_with("/some/project", "user")
 
+    def test_rm_removes_user_scope_plugin(self, cli_runner, sample_module, tmp_path):
+        """mod rm removes user-scope plugin directory."""
+        from unittest.mock import MagicMock
+        from lola.models import Installation, InstallationRegistry
+        from lola.targets.base import PluginLayout
+
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+
+        dest = modules_dir / "sample-module"
+        shutil.copytree(sample_module, dest)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="sample-module",
+                assistant="cursor",
+                scope="user",
+                skills=["skill1"],
+                is_plugin=True,
+            )
+        )
+
+        plugin_dir = tmp_path / "plugins" / "sample-module"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text('{"name": "sample-module"}')
+
+        layout = PluginLayout(
+            plugin_root_template=str(tmp_path / "plugins" / "{name}"),
+            manifest_path=None,
+            mcp_path="mcp.json",
+        )
+        mock_target = MagicMock()
+        mock_target.get_plugin_layout.return_value = layout
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.INSTALLED_FILE", installed_file),
+            patch("lola.cli.mod.get_target", return_value=mock_target),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["rm", "sample-module", "-f"])
+
+        assert result.exit_code == 0
+        assert not plugin_dir.exists()
+
 
 class TestModRmInteractive:
     """Tests for mod rm interactive picker (no argument)."""

--- a/tests/test_cursor_target.py
+++ b/tests/test_cursor_target.py
@@ -1,6 +1,8 @@
 """Tests for CursorTarget scope-aware path resolution."""
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from lola.targets.cursor import CursorTarget
 
@@ -102,3 +104,57 @@ def test_cursor_mcp_path_default_scope():
     target = CursorTarget()
     result = target.get_mcp_path("/home/user/project")
     assert result == Path("/home/user/project/.cursor/mcp.json")
+
+
+# --- Plugin tests ---
+
+
+def test_cursor_plugin_layout_project_not_supported():
+    target = CursorTarget()
+    assert target.get_plugin_layout("project") is None
+
+
+def test_cursor_plugin_layout_user():
+    target = CursorTarget()
+    layout = target.get_plugin_layout("user")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "user", None)
+    assert root == Path.home() / ".cursor" / "plugins" / "local" / "my-pack"
+
+
+def test_cursor_plugin_layout_manifest_path():
+    target = CursorTarget()
+    layout = target.get_plugin_layout("user")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "user", None)
+    paths = layout.resolve_paths(root)
+    # Global spec: plugin.json at root, not .cursor-plugin/
+    assert paths["manifest"] == root
+
+
+def test_cursor_plugin_layout_mcp_path():
+    target = CursorTarget()
+    layout = target.get_plugin_layout("user")
+    assert layout is not None
+    root = layout.resolve_root("my-pack", "user", None)
+    paths = layout.resolve_paths(root)
+    assert paths["mcp"] == root / "mcp.json"
+
+
+def test_cursor_build_manifest_uses_existing(tmp_path):
+    target = CursorTarget()
+    (tmp_path / "plugin.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                "name": "from-pack",
+                "version": "3.0.0",
+            }
+        )
+    )
+    module = MagicMock()
+    module.name = "my-pack"
+    module.content_path = tmp_path
+    manifest = target.build_plugin_manifest(module)
+    assert manifest.name == "from-pack"
+    assert manifest.version == "3.0.0"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 
 from lola.targets import get_registry, copy_module_to_local, install_to_assistant
-from lola.models import Module, InstallationRegistry
+from lola.models import Installation, Module, InstallationRegistry
 
 
 class TestGetRegistry:
@@ -264,6 +264,84 @@ Do {cmd}.
     # Note: test_install_missing_skill_source and test_install_missing_command_source
     # were removed because with auto-discovery, skills and commands are only
     # discovered if they actually exist. There's no manifest to list non-existent items.
+
+    def test_standard_install_blocks_plugin_reinstall(self, tmp_path):
+        """Cannot install as plugin when already installed as standard."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="testmod",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                skills=["skill1"],
+                is_plugin=False,
+            )
+        )
+
+        module = self.create_test_module(tmp_path, skills=["skill1"])
+        local_modules = tmp_path / ".lola" / "modules"
+        local_modules.mkdir(parents=True)
+
+        mock_target = MagicMock()
+        mock_target.name = "claude-code"
+
+        with (
+            patch("lola.targets.console", self.console_mock),
+            patch("lola.targets.get_target", return_value=mock_target),
+        ):
+            count = install_to_assistant(
+                module=module,
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                local_modules=local_modules,
+                registry=registry,
+                as_plugin=True,
+            )
+
+        assert count == 0
+
+    def test_plugin_install_blocks_standard_reinstall(self, tmp_path):
+        """Cannot install as standard when already installed as plugin."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="testmod",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                skills=["skill1"],
+                is_plugin=True,
+            )
+        )
+
+        module = self.create_test_module(tmp_path, skills=["skill1"])
+        local_modules = tmp_path / ".lola" / "modules"
+        local_modules.mkdir(parents=True)
+
+        mock_target = MagicMock()
+        mock_target.name = "claude-code"
+
+        with (
+            patch("lola.targets.console", self.console_mock),
+            patch("lola.targets.get_target", return_value=mock_target),
+        ):
+            count = install_to_assistant(
+                module=module,
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                local_modules=local_modules,
+                registry=registry,
+                as_plugin=False,
+            )
+
+        assert count == 0
 
 
 class TestGenerationIsIdempotent:

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -678,6 +678,7 @@ class TestUninstallWithInstructions:
         mock_target.get_instructions_path.return_value = claude_md
         mock_target.remove_skill.return_value = True
         mock_target.remove_instructions.return_value = True
+        mock_target.get_plugin_layout.return_value = None
 
         runner = CliRunner()
         with (

--- a/tests/test_targets_base.py
+++ b/tests/test_targets_base.py
@@ -1,8 +1,16 @@
 """Tests for AssistantTarget ABC scope parameter support."""
 
+import json
 from pathlib import Path
 
-from lola.targets.base import AssistantTarget
+import pytest
+
+from lola.targets.base import (
+    _PLUGIN_SCHEMA,
+    AssistantTarget,
+    PluginLayout,
+    PluginManifest,
+)
 
 
 class MockTarget(AssistantTarget):
@@ -104,3 +112,175 @@ def test_get_command_path_user_scope():
     target = MockTarget()
     path = target.get_command_path("/home/user/project", "user")
     assert path == Path.home() / ".mock" / "commands"
+
+
+# =============================================================================
+# PluginManifest tests
+# =============================================================================
+
+
+class TestPluginManifest:
+    def test_name_required(self):
+        with pytest.raises(ValueError, match="non-empty name"):
+            PluginManifest(name="")
+
+    def test_to_dict_minimal(self):
+        m = PluginManifest(name="my-plugin")
+        d = m.to_dict()
+        assert d["$schema"] == _PLUGIN_SCHEMA
+        assert d["name"] == "my-plugin"
+        assert "version" not in d
+
+    def test_to_dict_all_fields(self):
+        m = PluginManifest(
+            name="my-plugin",
+            version="1.0.0",
+            description="A test plugin",
+            author={"name": "Test", "email": "t@t.com", "extra": "ignored"},
+            homepage="https://example.com",
+            repository="https://github.com/test/plugin",
+            license="MIT",
+            keywords=["test", "plugin"],
+            extensions={"com.example": {"key": "value"}},
+        )
+        d = m.to_dict()
+        assert d["version"] == "1.0.0"
+        assert d["description"] == "A test plugin"
+        assert d["author"] == {"name": "Test", "email": "t@t.com"}
+        assert "extra" not in d["author"]
+        assert d["homepage"] == "https://example.com"
+        assert d["repository"] == "https://github.com/test/plugin"
+        assert d["license"] == "MIT"
+        assert d["keywords"] == ["test", "plugin"]
+        assert d["extensions"] == {"com.example": {"key": "value"}}
+
+    def test_write(self, tmp_path):
+        m = PluginManifest(name="my-plugin", version="1.0.0")
+        manifest_dir = tmp_path / "manifest"
+        result = m.write(manifest_dir)
+        assert result is True
+        assert (manifest_dir / "plugin.json").exists()
+        data = json.loads((manifest_dir / "plugin.json").read_text())
+        assert data["name"] == "my-plugin"
+        assert data["version"] == "1.0.0"
+
+    def test_from_file(self, tmp_path):
+        plugin_json = tmp_path / "plugin.json"
+        plugin_json.write_text(
+            json.dumps(
+                {
+                    "$schema": _PLUGIN_SCHEMA,
+                    "name": "existing-plugin",
+                    "version": "2.0.0",
+                    "description": "From file",
+                }
+            )
+        )
+        m = PluginManifest.from_file(plugin_json)
+        assert m is not None
+        assert m.name == "existing-plugin"
+        assert m.version == "2.0.0"
+        assert m.description == "From file"
+
+    def test_from_file_missing(self, tmp_path):
+        m = PluginManifest.from_file(tmp_path / "nonexistent.json")
+        assert m is None
+
+    def test_from_file_invalid_json(self, tmp_path):
+        bad_file = tmp_path / "plugin.json"
+        bad_file.write_text("not json")
+        m = PluginManifest.from_file(bad_file)
+        assert m is None
+
+    def test_from_file_no_name(self, tmp_path):
+        no_name = tmp_path / "plugin.json"
+        no_name.write_text(json.dumps({"version": "1.0.0"}))
+        m = PluginManifest.from_file(no_name)
+        assert m is None
+
+
+# =============================================================================
+# PluginLayout tests
+# =============================================================================
+
+
+class TestPluginLayout:
+    def test_resolve_root_project(self):
+        layout = PluginLayout(
+            plugin_root_template=".test/plugins/{name}",
+            manifest_path=".test-plugin",
+            mcp_path="mcp-config.json",
+        )
+        root = layout.resolve_root("my-pack", "project", "/home/user/project")
+        assert root == Path("/home/user/project/.test/plugins/my-pack")
+
+    def test_resolve_root_user(self):
+        layout = PluginLayout(
+            plugin_root_template="~/.test/plugins/{name}",
+            manifest_path=".test-plugin",
+            mcp_path="mcp-config.json",
+        )
+        root = layout.resolve_root("my-pack", "user", None)
+        assert root == Path.home() / ".test" / "plugins" / "my-pack"
+
+    def test_resolve_paths_all(self):
+        layout = PluginLayout(
+            plugin_root_template=".test/plugins/{name}",
+            manifest_path=".test-plugin",
+            mcp_path="mcp-config.json",
+        )
+        root = Path("/project/.test/plugins/my-pack")
+        paths = layout.resolve_paths(root)
+        assert paths["skills"] == root / "skills"
+        assert paths["agents"] == root / "agents"
+        assert paths["commands"] == root / "commands"
+        assert paths["mcp"] == root / "mcp-config.json"
+        assert paths["manifest"] == root / ".test-plugin"
+        assert paths["instructions"] is None
+
+    def test_resolve_paths_none_components(self):
+        layout = PluginLayout(
+            plugin_root_template=".test/{name}",
+            manifest_path=None,
+            mcp_path=None,
+            agents_path=None,
+            commands_path=None,
+        )
+        root = Path("/project/.test/my-pack")
+        paths = layout.resolve_paths(root)
+        assert paths["skills"] == root / "skills"
+        assert paths["agents"] is None
+        assert paths["commands"] is None
+        assert paths["mcp"] is None
+        assert paths["manifest"] == root
+
+    def test_defaults(self):
+        layout = PluginLayout(
+            plugin_root_template=".test/{name}",
+            manifest_path=".test-plugin",
+            mcp_path="mcp.json",
+        )
+        assert layout.skills_path == "skills"
+        assert layout.agents_path == "agents"
+        assert layout.commands_path == "commands"
+        assert layout.instructions_path is None
+
+
+# =============================================================================
+# AssistantTarget plugin support tests
+# =============================================================================
+
+
+def test_get_plugin_layout_default_none():
+    target = MockTarget()
+    assert target.get_plugin_layout() is None
+    assert target.get_plugin_layout("user") is None
+
+
+def test_build_plugin_manifest_raises_for_unsupported():
+    from unittest.mock import MagicMock
+
+    target = MockTarget()
+    mock_module = MagicMock()
+    with pytest.raises(NotImplementedError, match="mock does not support plugins"):
+        target.build_plugin_manifest(mock_module)


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why (1-3 bullet points) -->

- Add `--plugin` flag to `lola install` and `lola uninstall` for installing modules as native plugin bundles instead of individual files
- Implemented for Claude Code (project + user scope) and Cursor (user scope only, using the [Agent Plugins](https://agent-plugins.org/) global spec format)
- If the pack includes a `plugin.json`, Lola uses it as-is; otherwise generates a manifest per the target implementation

## Related Issues

<!-- Fixes #123, Relates to #456 -->

Resolves LobsterTrap/lola#179
Contributes to LobsterTrap/lola#232
Documented in [APPENG-5866](https://redhat.atlassian.net/browse/APPENG-5866)

## Spec / ADR Reference

<!-- If this PR implements an architectural decision or a     -->
<!-- spec, link it here. Leave blank for small fixes and docs. -->

Relates to: docs/adr/agent-plugins-format.md

## Test Plan

<!-- How can reviewers verify this works? -->

- [x] Abstraction layer tests (PluginManifest, PluginLayout, AssistantTarget defaults)
- [x] Claude Code target plugin tests (layout, paths, manifest generation, existing plugin.json)
- [x] Cursor target plugin tests (layout, project not supported, global spec, existing plugin.json)
- [x] Install/uninstall interaction tests (4 combinations of plugin/standard)
- [x] Manual testing with [dummy packs](https://github.com/TomerFi/lola-dummy-packs):
  - Claude Code [project](https://drive.google.com/file/d/1BlFNgShHSOKJ18SbcwgLQVUoUhdmv9i2/view?usp=drive_link) and [user](https://drive.google.com/file/d/19HDSOQMuF1VxsiuqXGpzTve_fx7gB7Hj/view?usp=drive_link) without existing plugin.json
  - Claude Code [project](https://drive.google.com/file/d/1WwJbuv8_IDX6L3COjX3Z-lzuqJ-f6AQn/view?usp=drive_link) and [user](https://drive.google.com/file/d/1jIIs9Q4GxSU_Jfhz_l0i_mc1KW_c8zCC/view?usp=drive_link) with existing plugin.json
  - Cursor [user](https://drive.google.com/file/d/1MT_sIWToec1InJZZKgJN9gt-R_6iAspU/view?usp=drive_link) without existing plugin.json
  - Uninstall: [user plugin→plugin](https://drive.google.com/file/d/1hc6hXuqL6CLawkQyuz9mEZWSKYcY5iKW/view?usp=drive_link), [user plugin→standard](https://drive.google.com/file/d/1t7D3uqzkrisIt8o2HluNd0Xno-wHDfSQ/view?usp=drive_link), [user standard→plugin](https://drive.google.com/file/d/1YZOJAMrpNKFsZlftm-SFpcy8nX-p654x/view?usp=drive_link), [user standard→standard](https://drive.google.com/file/d/14s36CzBiB2nNfb5PO2N6WHhVgGUEdn2W/view?usp=drive_link), [project plugin→plugin](https://drive.google.com/file/d/1KPzWea8ru-A_XHsYX6ADBlqo59Gky3Z4/view?usp=drive_link), [project plugin→standard](https://drive.google.com/file/d/1-85qSHif797DAsgc_nNXJ5I9tKOipnd3/view?usp=drive_link), [project standard→plugin](https://drive.google.com/file/d/1DFYspZqxc7xb9BIzHyjORQnwezbaPNnl/view?usp=drive_link), [project standard→standard](https://drive.google.com/file/d/1Er19Dthwwus3U3sOep0ELBB0JsVdrjFR/view?usp=drive_link)

## Checklist

- [x] Tests pass (`pytest` / `go test -race ./...`)
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`)
- [ ] `go vet ./...` passes (Go changes only, N/A otherwise)
- [x] Type checking passes (`uv run ty check`)
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [ ] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Install, update, and uninstall modules as self-contained plugins with `--plugin`.
  - Automatically create or reuse plugin manifests.
  - Added plugin support for Claude Code and Cursor where supported.

- **Bug Fixes**
  - Improved reporting and removal of plugin installations.
  - Prevented mismatched standard and plugin installation modes.
  - Clarified behavior for unsupported clients and scopes.

- **Documentation**
  - Added guides covering commands, supported clients and scopes, troubleshooting, and plugin installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
